### PR TITLE
Use S3 website URL for staging and production documentation redirects

### DIFF
--- a/_production-redirects
+++ b/_production-redirects
@@ -1,1 +1,1 @@
-/documentation/* https://documentation-production.s3.amazonaws.com/documentation/:splat 200!
+/documentation/* http://documentation-production.s3-website-us-east-1.amazonaws.com/documentation/:splat 200!

--- a/_staging-redirects
+++ b/_staging-redirects
@@ -1,1 +1,1 @@
-/documentation/* https://documentation-staging.s3.amazonaws.com/documentation/:splat 200!
+/documentation/* http://documentation-staging.s3-website-us-east-1.amazonaws.com/documentation/:splat 200!


### PR DESCRIPTION
~~Don't merge just yet, opening PR to test on a netlify build preview.~~ Verified this fixes the issue.  Example link: https://deploy-preview-22--aptible-staging.netlify.com/documentation/deploy/tutorials/faq/aptible-base-images.html

This is ready for review/deploy.

cc @fancyremarker @thomasthesecond 