### PR TITLE
adjusted header to match docs

### DIFF
--- a/src/components/header/Header.module.css
+++ b/src/components/header/Header.module.css
@@ -64,7 +64,7 @@
 }
 
 @media (--mobile) {
-  .headerContainer.open {
+  .headerContainer {
     height: 56px;
   }
 

--- a/src/components/signup/SignupButton.js
+++ b/src/components/signup/SignupButton.js
@@ -5,15 +5,8 @@ import Signup from './Signup';
 class SignupButton extends React.Component {
   constructor(props) {
     super(props);
-
-    let defaultOpen = false;
-    if (typeof window !== 'undefined') {
-      if (window.location.pathname === "/" && window.location.hash === "#schedule") {
-        defaultOpen = true;
-      }
-    }
     this.state = {
-      open: defaultOpen
+      open: false,
     };
   }
 

--- a/src/components/signup/SignupPage.js
+++ b/src/components/signup/SignupPage.js
@@ -26,7 +26,7 @@ class SignupPage extends React.Component {
       <React.Fragment>
         <h1>Signup</h1>
         {this.state.open &&
-          <Signup closeFn={this.closeSignup} />
+          <Signup closeFn={this.closeSignup} product={this.props.product} />
         }
       </React.Fragment>
     );

--- a/src/pages/signup-comply.js
+++ b/src/pages/signup-comply.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import AptibleLayout from '../components/layouts/AptibleLayout';
+import SignupPage from '../components/signup/SignupPage';
+
+export default () => (
+  <AptibleLayout>
+    <Helmet>
+      <title>Aptible | Signup</title>
+      <meta name="description" content="Aptible is the leading security management platform for small companies. Grow by meeting security requirements for SOC 2, ISO 27001, HIPAA, GDPR, and more." />
+    </Helmet>
+    <SignupPage product="comply" />
+  </AptibleLayout>
+);


### PR DESCRIPTION
Some adjustments needed to make the header consistent with updates to the header on the docs portion of the site.

This also now opens the Signup modal when you add #schedule to the home url (e.g. aptible.com/#schedule)

This should be merged along with https://github.com/aptible/docs/pull/157