### PR TITLE
Temporarily remove the owners manual pages query

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -293,21 +293,21 @@ exports.createPages = ({ graphql, actions }) => {
         });
       }
 
-      result.data.allOwnersManualPages.edges.forEach(({ node }) => {
-        let pagePath = 'owners-manual';
-        if (node.slug) {
-          pagePath += `/${node.slug}`;
-        }
+      // result.data.allOwnersManualPages.edges.forEach(({ node }) => {
+      //   let pagePath = 'owners-manual';
+      //   if (node.slug) {
+      //     pagePath += `/${node.slug}`;
+      //   }
 
-        createPage({
-          path: pagePath,
-          component: path.resolve(`./src/templates/owners-manual.js`),
-          context: {
-            activePath: node.slug,
-            allPages: result.data.allOwnersManualPages.edges
-          },
-        });
-      });
+      //   createPage({
+      //     path: pagePath,
+      //     component: path.resolve(`./src/templates/owners-manual.js`),
+      //     context: {
+      //       activePath: node.slug,
+      //       allPages: result.data.allOwnersManualPages.edges
+      //     },
+      //   });
+      // });
 
       resolve();
     });

--- a/src/templates/owners-manual.js
+++ b/src/templates/owners-manual.js
@@ -9,14 +9,13 @@ const getCurrentPage = (activePath, allPages) => {
 }
 
 export default ({ pageContext }) => {
-  console.log(pageContext);
   const currentPage = getCurrentPage(pageContext.activePath, pageContext.allPages);
 
   return (
     <AptibleLayout>
       <Helmet>
         <title>{currentPage.displayTitle || currentPage.title} | Aptible Owners Manual</title>
-        <meta name="description" content="Meta description here." />
+        <meta name="description" content="" />
       </Helmet>
       <Page currentPage={currentPage} allPages={pageContext.allPages} />
     </AptibleLayout>


### PR DESCRIPTION
The owners manual pages seem to be causing an issue when deploying to production. I think because the entries are still in draft.