### PR TITLE
Update pricing slider text for mobile

### DIFF
--- a/src/components/pricing/PricingSlider.module.css
+++ b/src/components/pricing/PricingSlider.module.css
@@ -96,4 +96,9 @@
   .tick {
     margin-top: 48px;
   }
+
+  .includedText span {
+    top: -10px;
+    background-color: var(--aptible-black-light);
+  }
 }


### PR DESCRIPTION
"Included" text was not aligned and the background was too dark.

<img width="160" alt="image" src="https://user-images.githubusercontent.com/1479563/74749441-2aec5900-5238-11ea-8c61-661e0edfdeab.png">
