### PR TITLE
Remove references to the parent entry for owners manual

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -135,10 +135,6 @@ exports.createPages = ({ graphql, actions }) => {
               section
               slug
               hidePage
-              contentfulparent {
-                title
-                slug
-              }
               body {
                 json
               }

--- a/src/components/owners-manual/Subnav.js
+++ b/src/components/owners-manual/Subnav.js
@@ -7,7 +7,7 @@ import styles from './Subnav.module.css';
 const SECTIONS = ['Our Business', 'Our Culture', 'Our Teams'];
 
 const Section = ({ section, allPages }) => {
-  const sectionRootPages = allPages.filter(e => e.node.contentfulparent === null && e.node.section === section);
+  const sectionRootPages = allPages.filter(e => e.node.section === section);
   if (sectionRootPages.length < 1) {
     return null;
   }
@@ -51,7 +51,7 @@ const pagePath = (page) => {
 }
 
 export default ({ allPages }) => {
-  const rootWithoutSection = allPages.filter(e => e.node.contentfulparent === null && e.node.section === null);
+  const rootWithoutSection = allPages.filter(e => e.node.section === null);
 
   return (
     <SidebarNav title="Owner’s Manual">


### PR DESCRIPTION
Some entries were published in Contentful that should not have been. Resetting these entries back to draft status seems to break the production build because there are no entries with a parent.

As I understand it, the query is looking for entries with a parent `contentfulparent` and if the published entries don't have a parent assigned, then this query fails.

In the future, we can revert this change, but for now it's the only way I was able to figure out how to fix the production build after un-publishing entries with a parent.