### PR TITLE
Add go to next section button for owner's manual pages

### DIFF
--- a/src/components/buttons/ArrowButton.js
+++ b/src/components/buttons/ArrowButton.js
@@ -23,6 +23,7 @@ class ArrowButton extends React.Component {
           className={styles.link}
           onMouseEnter={() => this.setHover(true)}
           onMouseLeave={() => this.setHover(false)}
+          title={this.props.title}
         >
           {this.props.text}
           <div className={styles.arrowContainer}>
@@ -41,6 +42,7 @@ class ArrowButton extends React.Component {
           onClick={this.props.onClickFn}
           role="button"
           tabIndex={0}
+          title={this.props.title}
         >
           {this.props.text}
           <div className={styles.arrowContainer}>
@@ -56,6 +58,7 @@ class ArrowButton extends React.Component {
         className={styles.link}
         onMouseEnter={() => this.setHover(true)}
         onMouseLeave={() => this.setHover(false)}
+        title={this.props.title}
       >
         {this.props.text}
         <div className={styles.arrowContainer}>

--- a/src/components/owners-manual/Page.js
+++ b/src/components/owners-manual/Page.js
@@ -4,25 +4,42 @@ import styles from './Page.module.css';
 import Subnav from './Subnav';
 import ShareIcons from '../shared/ShareIcons';
 import ContentfulRichText from '../contentful/ContentfulRichText';
+import ArrowButton from '../buttons/ArrowButton';
 
-export default ({ currentPage, allPages }) => (
-  <div className={styles.container}>
-    <Grid>
-      <div className={styles.hero}>
-        <h1>{currentPage.displayTitle || currentPage.title}</h1>
-      </div>
+export default ({ currentPage, allPages }) => {  
+  const currentIndex = allPages.map(page => page.node.title).indexOf(currentPage.title);
+  const nextIndex = currentIndex + 1;
+  const nextPage = allPages.length !== nextIndex ? allPages[nextIndex] : null;
 
-      <div className={styles.meta}>
-        <ShareIcons />
-      </div>
+  return (
+    <div className={styles.container}>
+      <Grid>
+        <div className={styles.hero}>
+          <h1>{currentPage.displayTitle || currentPage.title}</h1>
+        </div>
 
-      <div className={styles.sidebar}>
-        <Subnav allPages={allPages} />
-      </div>
+        <div className={styles.meta}>
+          <ShareIcons />
+        </div>
 
-      <div className={styles.content}>
-        <ContentfulRichText json={currentPage.body.json} />
-      </div>
-    </Grid>
-  </div>
-);
+        <div className={styles.sidebar}>
+          <Subnav allPages={allPages} />
+        </div>
+
+        <div className={styles.content}>
+          <ContentfulRichText json={currentPage.body.json} />
+
+          {nextPage && (
+            <div className={styles.nextSection}>
+              <ArrowButton
+                to={`/owners-manual/${nextPage.node.slug}`}
+                title={`Go to ${nextPage.node.title}`}
+                text="Go to Next Section"
+              />
+            </div>
+          )}
+        </div>
+      </Grid>
+    </div>
+  );
+};

--- a/src/components/owners-manual/Page.module.css
+++ b/src/components/owners-manual/Page.module.css
@@ -48,6 +48,10 @@
   grid-column: 6 / span 2;
 }
 
+.nextSection {
+  margin-top: 60px;
+}
+
 @media (--mobile) {
   .meta {
     padding-bottom: 30px;
@@ -63,5 +67,10 @@
     grid-row: 4;
     grid-column: 1 / span 7;
     padding-bottom: 30px;
+  }
+
+  .nextSection {
+    margin-bottom: 20px;
+    margin-top: 30px;
   }
 }


### PR DESCRIPTION
Added a link to the bottom of each owner's manual page that links to the next page in the navigation. The last page doesn't have a link.

<img width="1165" alt="image" src="https://user-images.githubusercontent.com/1479563/84179384-d9b8dd00-aa53-11ea-87cc-f68624c911f5.png">
