### PR TITLE
Block free emails from Comply signups

### DIFF
--- a/src/components/resources/ResourceCard.js
+++ b/src/components/resources/ResourceCard.js
@@ -25,8 +25,9 @@ export default ({ resource }) => {
   
   const isDocumentationUrl = resource.url.includes("documentation");
   const isPdfUrl = resource.url.includes(".pdf");
+  const isExternalUrl = resource.url.includes("http");
   
-  return (isDocumentationUrl || isPdfUrl) ? (
+  return (isDocumentationUrl || isPdfUrl || isExternalUrl) ? (
     <a href={resource.url} className={styles.container}>
       <LinkContent />
     </a>

--- a/src/components/signup/Email.js
+++ b/src/components/signup/Email.js
@@ -38,11 +38,20 @@ class Email extends React.Component {
     }
   }
 
+  isFreeEmail = () => {
+    return this.state.email.match(/(gmail|yahoo|hotmail|aol|icloud)/)
+  }
+
   buttonClick = () => {
     if (this.state.email.length > 0 && this.state.email.indexOf('@') !== -1) {
       if (this.props.signupState.product === 'comply' && this.state.personaAnswer === '') {
         alert('Please tell us what\'s most important to you right now');
         return;
+      }
+
+      if (this.props.signupState.product !== 'deploy' && this.isFreeEmail()) {
+        alert('Please use your work email address');
+        return
       }
 
       this.props.setEmail(this.state.email, this.state.marketingConsent, this.state.personaAnswer);

--- a/src/data/resources.json
+++ b/src/data/resources.json
@@ -31,8 +31,8 @@
   },
   {
     "title": "Components of an Effective Vendor Management Program",
-    "url": "/security-management/vendor-management/",
-    "description": "In this guide, we cover why vendor management is important, the essentials of an effective vendor management program, and information on how to use Aptible’s various vendor management tools and features to manage vendors securely.",
+    "url": "https://pages.aptible.com/Vendor-Management-Guide.html",
+    "description": "Looking to move beyond the basics of vendor management and start to streamline and automate your internal processes? Download this guide to learn how to level up your approach to vendor management to reduce risk and speed up sales cycles.",
     "tags": ["Guide"]
   },
   {

--- a/src/html.js
+++ b/src/html.js
@@ -55,22 +55,6 @@ adroll_pix_id = "ERBZPRNMMFELHNLX5C3Y34";
     if (window.addEventListener) {window.addEventListener('load', _onload, false);}
     else {window.attachEvent('onload', _onload)}
 }());
-
-var sf14gv = 32857;
-(function() {
-  var sf14g = document.createElement('script');
-  sf14g.src = 'https://tracking.leadlander.com/lt.min.js';
-  var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(sf14g, s);
-})();
-
-(function () {
-  var zi = document.createElement('script');
-  zi.type = 'text/javascript';
-  zi.async = true;
-  zi.src = 'https://ws.zoominfo.com/pixel/oWUZ2VKQg8kZQNmDHm5U';
-  var s = document.getElementsByTagName('script')[0];
-  s.parentNode.insertBefore(zi, s);
-})();
 `;
 
 const segmentJs = `


### PR DESCRIPTION
Demand gen asked that we prevent visitors from using free email providers to sign up for Comply demos.

Also updated a resources link and removed some services we no longer use.