### PR TITLE
Fix flash of unstyled content on sign up page

### DIFF
--- a/src/components/signup/SignupPage.js
+++ b/src/components/signup/SignupPage.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Signup from './Signup';
+import styles from './SignupPage.module.css';
 
 class SignupPage extends React.Component {
   constructor(props) {
@@ -24,7 +25,9 @@ class SignupPage extends React.Component {
   render() {
     return (
       <React.Fragment>
-        <h1>Signup</h1>
+        <div className={styles.container}>
+          <h1 className={styles.heading}>Signup</h1>
+        </div>
         {this.state.open &&
           <Signup closeFn={this.closeSignup} product={this.props.product} />
         }

--- a/src/components/signup/SignupPage.module.css
+++ b/src/components/signup/SignupPage.module.css
@@ -1,0 +1,7 @@
+.container {
+  min-height: 50vh;
+}
+
+.heading {
+  display: none;
+}


### PR DESCRIPTION
I noticed a brief flash before the sign up overlay loads. This PR hides the title and adds a min-height to the container to push the footer down a bit.

https://www.loom.com/share/03728c2cd6e1449698287f4a5e13944a

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/1479563/88972896-4302e280-d284-11ea-9929-701bf2d9ed71.png">

