### PR TITLE
Add blog categories, update navigation

### DIFF
--- a/src/components/footer/Footer.js
+++ b/src/components/footer/Footer.js
@@ -61,6 +61,7 @@ export default () => (
         <Link to="/customers/">Customers</Link>
         <Link to="/hipaa/">Compliance Guides</Link>
         <Link to="/blog/">Blog</Link>
+        <Link to="/blog/category/engineering/">Engineering Blog</Link>
       </div>
 
       <div className={styles.support}>
@@ -77,6 +78,7 @@ export default () => (
         <Link to="/company/">About</Link>
         <Link to="/careers/">Careers</Link>
         <Link to="/press/">Press</Link>
+        <Link to="/owners-manual/">Owner’s Manual</Link>
         <Link to="/legal/terms-of-service/">Legal</Link>
       </div>
 

--- a/src/components/header/Company.js
+++ b/src/components/header/Company.js
@@ -11,16 +11,12 @@ export default () => (
           <div>About</div>
         </Link>
 
-        <Link to="/blog/">
-          <div>Blog</div>
+        <Link to="/careers/">
+          <div>Careers</div>
         </Link>
 
         <Link to="/press/">
-          <div>News</div>
-        </Link>
-
-        <Link to="/careers/">
-          <div>Careers</div>
+          <div>Press</div>
         </Link>
 
         <Link to="/owners-manual/">

--- a/src/components/header/Resources.js
+++ b/src/components/header/Resources.js
@@ -11,6 +11,14 @@ export default () => (
           <div>Security Management Resources</div>
         </Link>
 
+        <Link to="/blog/">
+          <div>Blog</div>
+        </Link>
+
+        <Link to="/blog/category/engineering/">
+          <div>Engineering Blog</div>
+        </Link>
+
         <a href="/documentation/index.html">
           <div>Product Documentation</div>
         </a>

--- a/src/data/blog-categories.json
+++ b/src/data/blog-categories.json
@@ -14,5 +14,9 @@
   {
     "title": "Engineering",
     "slug": "engineering"
+  },
+  {
+    "title": "Working @ Aptible",
+    "slug": "working-at-aptible"
   }
 ]


### PR DESCRIPTION
https://aptible.atlassian.net/browse/WWW-14

* Add "Working at Aptible" blog category to navigation
* Move blog from "about" menu to "resources" in header nav
* Add engineering blog to "resources" menu in header and footer nav
* Move careers under about in "company" menu in header nav; reflects order in footer nav
* Rename news to press in "company" menu header nav; reflects label in footer nav
* Add owner's manual link to footer nav under "company"

<img width="1281" alt="image" src="https://user-images.githubusercontent.com/1479563/89198319-0af8e980-d57b-11ea-8188-80f736408a10.png">

<img width="1238" alt="image" src="https://user-images.githubusercontent.com/1479563/89198338-121ff780-d57b-11ea-8d51-4a405f64fd65.png">

<img width="1128" alt="image" src="https://user-images.githubusercontent.com/1479563/89198350-1815d880-d57b-11ea-969b-ca350339dc9e.png">

<img width="1174" alt="image" src="https://user-images.githubusercontent.com/1479563/89198372-206e1380-d57b-11ea-8135-86d1e98c1665.png">
