### PR TITLE
Add defense in brief blog category

### DIFF
--- a/src/data/blog-categories.json
+++ b/src/data/blog-categories.json
@@ -18,5 +18,9 @@
   {
     "title": "Working @ Aptible",
     "slug": "working-at-aptible"
+  },
+  {
+    "title": "Defense in Brief",
+    "slug": "defense-in-brief"
   }
 ]


### PR DESCRIPTION
There is a defense in brief blog post going up this week. This must be merged after the blog post has been published.