### PR TITLE
Make all webinar presenters optional

### DIFF
--- a/src/components/webinars/Webinar.js
+++ b/src/components/webinars/Webinar.js
@@ -24,12 +24,16 @@ export default ({ webinar }) => (
 
         <ContentfulRichText json={webinar.body.json} />
 
-        <h3 style={{ paddingTop: '30px' }}>Presented By</h3>
-        <div className={styles.presenter}>
-          <img src={webinar.presenter1.professionalPhoto.file.url} alt={webinar.presenter1.name} />
-          <h5>{webinar.presenter1.name}</h5>
-          <p>{webinar.presenter1.jobTitle}</p>
-        </div>
+        {(webinar.presenter1 || webinar.presenter2) && (
+          <h3 style={{ paddingTop: '30px' }}>Presented By</h3>
+        )}
+        {webinar.presenter1 &&
+          <div className={styles.presenter}>
+            <img src={webinar.presenter1.professionalPhoto.file.url} alt={webinar.presenter1.name} />
+            <h5>{webinar.presenter1.name}</h5>
+            <p>{webinar.presenter1.jobTitle}</p>
+          </div>
+        }
         
         {webinar.presenter2 &&
           <div className={styles.presenter}>


### PR DESCRIPTION
https://aptible.atlassian.net/browse/WWW-19

There's a case with an upcoming webinar where presenters aren't Aptible-only and therefore the presenters are added to the webinar body copy.

If you pull down locally to test, you can use this entry: http://localhost:8001/webinars/test-webinar

<img width="1236" alt="image" src="https://user-images.githubusercontent.com/1479563/89222220-acdffc80-d5a2-11ea-8de1-23e1cb968fc3.png">
