### PR TITLE
Pull in webinar entries from Contentful for resources

### DIFF
--- a/src/components/resources/ResourceCards.js
+++ b/src/components/resources/ResourceCards.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { Grid } from '../grid/Grid';
 import styles from './ResourceCards.module.css';
 import ResourceCard from './ResourceCard';
-import resources from '../../data/resources.json';
 
 const FILTERS = {
   ALL: "All",
@@ -26,6 +25,7 @@ class ResourceCards extends React.Component {
   }
 
   render() {
+    const { resources } = this.props;
     const { activeFilter } = this.state;
 
     let filteredResources = resources;

--- a/src/data/resources.json
+++ b/src/data/resources.json
@@ -42,12 +42,6 @@
     "tags": ["Guide"]
   },
   {
-    "title": "Webinar Recap: Learn about Aptible Comply Workflows",
-    "url": "/webinars/workflows/",
-    "description": "In this recorded Webinar, Aptible Product Lead Chris Gomes and Product Marketing Manager Rob deJuana-Matthews discussed the release of Aptible Comply Workflows. Workflows helps Aptible Comply customers to keep track of everything they need to do on an ongoing basis to maintain compliance.",
-    "tags": ["Webinar"]
-  },
-  {
     "title": "CCPA Compliance: Guide for Startups",
     "url": "/ccpa/",
     "description": "What do startups and small businesses need to know about CCPA compliance? This guide explains the background of the CCPA, whom the CCPA applies to, and how to become CCPA-compliant.",
@@ -64,23 +58,5 @@
     "url": "/deploy/features/#division-of-responsibility",
     "description": "This guide is a breakdown of the functionalities (and their responsible parties) provided as part of the Deploy service.",
     "tags": ["Guide", "Deploy"]
-  },
-  {
-    "title": "Taking Compliance out of the Sales Cycle",
-    "url": "/webinars/taking-compliance-out-of-the-sales-cycle/",
-    "description": "Compliance teams at B2B SaaS companies are spending up to 25% of their time being pulled into sales conversations when prospects request security and compliance documentation. Not to mention the time that Sales, Legal, and Engineering spend to coordinate and fulfill these requests. Imagine if you could skip all the run-around and radically reduce the amount of time it takes to provide prospects with the information they need to buy.",
-    "tags": ["Webinar"]
-  },
-  {
-    "title": "Sneak Peek: Aptible Comply Integrations",
-    "url": "/webinars/sneak-peek-integrations/",
-    "description": "Aptible VP of Product Management Chris Gomes and Product Marketing Manager Rob deJuana-Matthews give an early look at Aptible Comply Integrations. Aptible Comply Integrations connects to every app that matters to you--every app that contains or touches sensitive data--and keeps track of your current security position, ensuring your company stays in compliance, so that you don’t have to.",
-    "tags": ["Webinar"]
-  },
-  {
-    "title": "The Death of Privacy Shield: What it means for your business",
-    "url": "/webinars/privacy-shield-no-more-what-it-means-for-businesses/",
-    "description": "With the EU Court of Justice invalidating Privacy Shield, what are the implications for businesses in the EU and US? Will the Standard Contractual Clauses remain effective for controlling information transfer? What does this mean from an operational perspective? The list of questions goes on! Watch our 30 minute recorded webinar with Aptible CEO, Chas Ballew, as we break down what this news means, what businesses are affected, and what are the options for your business as we move forward.",
-    "tags": ["Webinar"]
   }
 ]

--- a/src/pages/resources.js
+++ b/src/pages/resources.js
@@ -3,8 +3,19 @@ import { Helmet } from 'react-helmet';
 import AptibleLayout from '../components/layouts/AptibleLayout';
 import Introduction from '../components/resources/Introduction';
 import ResourceCards from '../components/resources/ResourceCards';
+import resources from '../data/resources.json';
 
-export default () => {
+export default ({ data }) => {
+  const webinars = data.posts.edges.map((webinar) => {
+    const { node } = webinar;
+    return {
+      title: node.title,
+      url: `/webinars/${node.slug}/`,
+      description: node.description ? node.description.description : '',
+      tags: ['Webinar', node.webinarType ? 'On Demand' : 'Upcoming'],
+    }
+  });
+  
   return (
     <AptibleLayout>
       <Helmet>
@@ -13,7 +24,24 @@ export default () => {
       </Helmet>
 
       <Introduction />
-      <ResourceCards />
+      <ResourceCards resources={[...resources, ...webinars]} />
     </AptibleLayout>
   )
 };
+
+export const query = graphql`
+  query {
+    posts: allContentfulWebinar {
+      edges {
+        node {
+          slug
+          title
+          description {
+            description
+          }
+          webinarType
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
This PR combines the resources.json file with an array of webinar entries from Contentful. Webinars are being added and updated frequently, so this change will allow marketing folks to manage this content on their own.

https://aptible.atlassian.net/browse/WWW-10

<img width="1189" alt="image" src="https://user-images.githubusercontent.com/1479563/89316516-3696d500-d64a-11ea-91e3-315922498cf1.png">
