### PR TITLE
Add Markdown and code block support for blog entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "build-production": "yarn run build && cp _redirects ./public/_redirects && cat _production-redirects >> ./public/_redirects",
     "build-staging": "yarn run build && cp _redirects ./public/_redirects && cat _staging-redirects >> ./public/_redirects",
     "build": "gatsby build",
-    "develop": "gatsby develop",
+    "develop": "gatsby develop -p 8001",
     "format": "prettier --write src/**/*.{js,jsx}",
-    "start": "npm run develop",
+    "start": "yarn run develop",
     "serve": "gatsby serve",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\""
   },
@@ -32,7 +32,9 @@
     "react": "^16.8.4",
     "react-compound-slider": "^2.0.0",
     "react-dom": "^16.8.4",
-    "react-helmet": "^5.2.1"
+    "react-helmet": "^5.2.1",
+    "react-markdown": "^4.3.1",
+    "react-syntax-highlighter": "^13.3.1"
   },
   "devDependencies": {
     "postcss-preset-env": "^6.6.0",

--- a/src/components/blog/ChangelogIndex.js
+++ b/src/components/blog/ChangelogIndex.js
@@ -3,6 +3,7 @@ import { Link } from 'gatsby';
 import { Grid } from '../grid/Grid';
 import styles from './Index.module.css';
 import Meta from './Meta';
+import Markdown from './Markdown';
 import blogCategories from '../../data/blog-categories.json';
 
 function ChangelogSummary({ post }) {
@@ -16,7 +17,12 @@ function ChangelogSummary({ post }) {
       <div className={styles.metaContainer}>
         <Meta post={post} disableAuthorLink="true" />
       </div>
-      <p>{post.excerpt.excerpt}</p>
+
+      {post.excerpt && (
+        <div className={styles.excerpt}>
+          <Markdown>{post.excerpt.excerpt}</Markdown>
+        </div>
+      )}
 
       <div className={styles.tags}>
         <span className={styles.tag}>{post.product}</span>

--- a/src/components/blog/CodeBlock.js
+++ b/src/components/blog/CodeBlock.js
@@ -1,0 +1,16 @@
+import React from "react";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { atomDark } from "react-syntax-highlighter/dist/esm/styles/prism";
+
+const CodeBlock = ({
+  value,
+  language
+}) => (
+  <div data-module="codeblock">
+    <SyntaxHighlighter language={language} style={atomDark}>
+      {value}
+    </SyntaxHighlighter>
+  </div>
+);
+
+export default CodeBlock;

--- a/src/components/blog/Index.js
+++ b/src/components/blog/Index.js
@@ -4,28 +4,37 @@ import { Grid } from '../grid/Grid';
 import styles from './Index.module.css';
 import ContentfulRichText from '../contentful/ContentfulRichText';
 import Meta from './Meta';
+import Markdown from './Markdown';
 import blogCategories from '../../data/blog-categories.json';
 
 function PostSummary({ post }) {
-  if (!post.body.json.content || post.body.json.content.length < 1) {
-    return '';
-  }
-
-  const firstContentNode = post.body.json.content[0];
   return (
     <Link className={styles.postSummary} to={`/blog/${post.slug}/`}>
-      <div className={styles.authorPhoto}>
-        <img src={post.author.professionalPhoto.file.url} alt={post.author.name} />
-        {post.secondAuthor &&
-          <img src={post.secondAuthor.professionalPhoto.file.url} alt={post.secondAuthor.name} />
-        }
-      </div>
+      {post.author && (
+        <div className={styles.authorPhoto}>
+          <img src={post.author.professionalPhoto.file.url} alt={post.author.name} />
+          {post.secondAuthor &&
+            <img src={post.secondAuthor.professionalPhoto.file.url} alt={post.secondAuthor.name} />
+          }
+        </div>
+      )}
 
       <h3>{post.title}</h3>
       <div className={styles.metaContainer}>
         <Meta post={post} disableAuthorLink="true" />
       </div>
-      <p><ContentfulRichText json={firstContentNode} /></p>
+
+      {post.body && (
+        <p>
+          <ContentfulRichText json={post.body.json.content[0]} />
+        </p>
+      )}
+
+      {post.excerpt && (
+        <div className={styles.excerpt}>
+          <Markdown>{post.excerpt.excerpt}</Markdown>
+        </div>
+      )}
 
       <div className={styles.tags}>
         {post.category.map((category, idx) => (

--- a/src/components/blog/Index.module.css
+++ b/src/components/blog/Index.module.css
@@ -91,6 +91,15 @@ a.activeCategory h6 {
   margin: 15px 0 45px 0;
 }
 
+.excerpt code {
+  background-color: rgba(255, 255, 255, 0.05);
+  color: rgb(150, 203, 254);
+  font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
+  padding-left: 4px;
+  padding-right: 4px;
+  font-size: 14px;
+}
+
 .tags {
   margin-top: 30px;
   float: right;

--- a/src/components/blog/Markdown.js
+++ b/src/components/blog/Markdown.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import CodeBlock from './CodeBlock';
+
+export default ({ children }) => (
+  <ReactMarkdown
+    source={children}
+    renderers={{ code: CodeBlock }}
+  />
+);

--- a/src/components/blog/Post.js
+++ b/src/components/blog/Post.js
@@ -1,38 +1,55 @@
 import React from 'react';
 import { Link } from 'gatsby';
+import ReactMarkdown from 'react-markdown';
 import { Grid } from '../grid/Grid';
 import styles from './Post.module.css';
 import ContentfulRichText from '../contentful/ContentfulRichText';
 import ShareIcons from '../shared/ShareIcons';
 import Meta from './Meta';
+import CodeBlock from "./CodeBlock";
 
 export default ({ post }) => (
-  <div className={styles.container}>
-    <Grid>
-      <div className={styles.authorPhoto}>
-        <img src={post.author.professionalPhoto.file.url} alt={post.author.name} />
-        {post.secondAuthor &&
-          <img src={post.secondAuthor.professionalPhoto.file.url} alt={post.secondAuthor.name} />
-        }
-      </div>
-
-      <div className={styles.content}>
-        <h5><Link to="/blog/">Blog</Link></h5>
-
-        <div className={styles.metaContainer}>
-          <Meta post={post} disableAuthorLink="true" />
-        </div>
-        
-        <h1>{post.title}</h1>
-
-        <div className={styles.share}>
-          <ShareIcons />
+  <>
+    <div className={styles.container}>
+      <Grid>
+        <div className={styles.authorPhoto}>
+          {post.author && 
+            <img src={post.author.professionalPhoto.file.url} alt={post.author.name} />
+          }
+          {post.secondAuthor &&
+            <img src={post.secondAuthor.professionalPhoto.file.url} alt={post.secondAuthor.name} />
+          }
         </div>
 
-        <div className={styles.body}>
-          <ContentfulRichText json={post.body.json} />
+        <div className={styles.content}>
+          <h5><Link to="/blog/">Blog</Link></h5>
+
+          <div className={styles.metaContainer}>
+            <Meta post={post} disableAuthorLink="true" />
+          </div>
+          
+          <h1>{post.title}</h1>
+
+          <div className={styles.share}>
+            <ShareIcons />
+          </div>
+
+          {post.body && (
+            <div className={styles.body}>
+              <ContentfulRichText json={post.body.json} />
+            </div>
+          )}
+
+          {post.bodyMarkdown && (
+            <div className={styles.body}>
+              <ReactMarkdown
+                source={post.bodyMarkdown.bodyMarkdown}
+                renderers={{ code: CodeBlock }}
+              />
+            </div>
+          )}
         </div>
-      </div>
-    </Grid>
-  </div>
+      </Grid>
+    </div>
+  </>
 );

--- a/src/components/blog/Post.js
+++ b/src/components/blog/Post.js
@@ -1,55 +1,51 @@
 import React from 'react';
 import { Link } from 'gatsby';
-import ReactMarkdown from 'react-markdown';
 import { Grid } from '../grid/Grid';
 import styles from './Post.module.css';
 import ContentfulRichText from '../contentful/ContentfulRichText';
 import ShareIcons from '../shared/ShareIcons';
 import Meta from './Meta';
-import CodeBlock from "./CodeBlock";
+import Markdown from './Markdown';
 
 export default ({ post }) => (
-  <>
-    <div className={styles.container}>
-      <Grid>
+  <div className={styles.container}>
+    <Grid>
+      {post.author && (
         <div className={styles.authorPhoto}>
-          {post.author && 
-            <img src={post.author.professionalPhoto.file.url} alt={post.author.name} />
-          }
+          <img src={post.author.professionalPhoto.file.url} alt={post.author.name} />
           {post.secondAuthor &&
             <img src={post.secondAuthor.professionalPhoto.file.url} alt={post.secondAuthor.name} />
           }
         </div>
+      )}
 
-        <div className={styles.content}>
-          <h5><Link to="/blog/">Blog</Link></h5>
+      <div className={styles.content}>
+        <h5><Link to="/blog/">Blog</Link></h5>
 
-          <div className={styles.metaContainer}>
-            <Meta post={post} disableAuthorLink="true" />
-          </div>
-          
-          <h1>{post.title}</h1>
-
-          <div className={styles.share}>
-            <ShareIcons />
-          </div>
-
-          {post.body && (
-            <div className={styles.body}>
-              <ContentfulRichText json={post.body.json} />
-            </div>
-          )}
-
-          {post.bodyMarkdown && (
-            <div className={styles.body}>
-              <ReactMarkdown
-                source={post.bodyMarkdown.bodyMarkdown}
-                renderers={{ code: CodeBlock }}
-              />
-            </div>
-          )}
+        <div className={styles.metaContainer}>
+          <Meta post={post} disableAuthorLink="true" />
         </div>
-      </Grid>
-    </div>
-  </>
+        
+        <h1>{post.title}</h1>
+
+        <div className={styles.share}>
+          <ShareIcons />
+        </div>
+
+        {post.body && (
+          <div className={styles.body}>
+            <ContentfulRichText json={post.body.json} />
+          </div>
+        )}
+
+        {post.bodyMarkdown && (
+          <div className={styles.body}>
+            <Markdown>
+              {post.bodyMarkdown.bodyMarkdown}
+            </Markdown>
+          </div>
+        )}
+      </div>
+    </Grid>
+  </div>
 );

--- a/src/components/blog/Post.module.css
+++ b/src/components/blog/Post.module.css
@@ -39,8 +39,9 @@
   padding: 40px 0;
 }
 
-.body {
-  max-width: 640px;
+.body h1 {
+  font-size: 40px;
+  line-height: 46px;
 }
 
 .body h2:not(:first-child),
@@ -54,12 +55,51 @@
   line-height: 1.6;
 }
 
+.body blockquote {
+  border-left: 4px solid var(--grid-lines-color);
+  margin-left: 0;
+  padding-left: 1em;
+}
+
+.body > *:not([data-module="codeblock"]) {
+  max-width: 640px;
+}
+
+.body > [data-module="codeblock"] {
+  width: var(--content-max-width);
+  margin-left: -160px;
+}
+
+/* override Prism theme */
+.body > [data-module="codeblock"] pre {
+  background-color: rgba(255, 255, 255, 0.05) !important;
+}
+
+.body :not(pre) > code {
+  background-color: rgba(255, 255, 255, 0.05);
+  color: rgb(150, 203, 254);
+  font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
+  padding-left: 4px;
+  padding-right: 4px;
+  font-size: 14px;
+}
+
 @media (--mobile) {
+  .body > [data-module="codeblock"] {
+    width: 100%;
+    margin-left: 0;
+  }
+
   .authorPhoto {
     display: none;
   }
 
   .content {
     grid-column: 1 / span 7;
+  }
+
+  .body h1 {
+    font-size: 20px;
+    line-height: 30px;
   }
 }

--- a/src/templates/blog-list-category.js
+++ b/src/templates/blog-list-category.js
@@ -65,6 +65,9 @@ export const query = graphql`
               }
             }
           }
+          excerpt {
+            excerpt
+          }
           body {
             json
           }

--- a/src/templates/blog-list.js
+++ b/src/templates/blog-list.js
@@ -59,6 +59,9 @@ export const query = graphql`
               }
             }
           }
+          excerpt {
+            excerpt
+          }
           body {
             json
           }

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -52,6 +52,9 @@ export const query = graphql`
           }
         }
       }
+      bodyMarkdown {
+        bodyMarkdown
+      }
       body {
         json
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2638,6 +2638,15 @@ cli-width@^2.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
   integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
 
+clipboard@^2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.6.tgz#52921296eec0fdf77ead1749421b21c968647376"
+  integrity sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==
+  dependencies:
+    good-listener "^1.2.2"
+    select "^1.1.2"
+    tiny-emitter "^2.0.0"
+
 cliui@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
@@ -3630,6 +3639,11 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
+delegate@^3.1.2:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.2.0.tgz#b66b71c3158522e8ab5744f720d8ca0c2af59166"
+  integrity sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==
+
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
@@ -3806,6 +3820,14 @@ dom-serializer@0:
     domelementtype "^1.3.0"
     entities "^1.1.1"
 
+dom-serializer@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
+  integrity sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
+  dependencies:
+    domelementtype "^2.0.1"
+    entities "^2.0.0"
+
 dom-walk@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
@@ -3821,6 +3843,11 @@ domelementtype@1, domelementtype@^1.3.0, domelementtype@^1.3.1:
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
   integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
 
+domelementtype@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.0.1.tgz#1f8bdfe91f5a78063274e803b4bdcedf6e94f94d"
+  integrity sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==
+
 domhandler@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.3.0.tgz#2de59a0822d5027fabff6f032c2b25a2a8abe738"
@@ -3834,6 +3861,13 @@ domhandler@^2.3.0:
   integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
   dependencies:
     domelementtype "1"
+
+domhandler@^3.0, domhandler@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-3.0.0.tgz#51cd13efca31da95bbb0c5bee3a48300e333b3e9"
+  integrity sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==
+  dependencies:
+    domelementtype "^2.0.1"
 
 domready@^1.0.8:
   version "1.0.8"
@@ -3855,6 +3889,15 @@ domutils@^1.7.0:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
+
+domutils@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.1.0.tgz#7ade3201af43703fde154952e3a868eb4b635f16"
+  integrity sha512-CD9M0Dm1iaHfQ1R/TI+z3/JWp/pgub0j4jIQKH89ARR4ATAV2nbaOQS5XxU9maJP5jHaPdDDQSEHuE2UmpUTKg==
+  dependencies:
+    dom-serializer "^0.2.1"
+    domelementtype "^2.0.1"
+    domhandler "^3.0.0"
 
 dot-prop@^4.1.0, dot-prop@^4.1.1:
   version "4.2.0"
@@ -4041,6 +4084,11 @@ entities@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
+
+entities@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
+  integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
 
 envinfo@^5.8.1:
   version "5.12.1"
@@ -4647,6 +4695,13 @@ fastparse@^1.1.1:
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"
   integrity sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==
 
+fault@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/fault/-/fault-1.0.4.tgz#eafcfc0a6d214fc94601e170df29954a4f842f13"
+  integrity sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==
+  dependencies:
+    format "^0.2.0"
+
 "favicons-webpack-plugin@https://github.com/Creatiwity/favicons-webpack-plugin.git#0872de414061baaad0a2853c77ae75bc38b8bbbf":
   version "0.0.9"
   resolved "https://github.com/Creatiwity/favicons-webpack-plugin.git#0872de414061baaad0a2853c77ae75bc38b8bbbf"
@@ -4985,6 +5040,11 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+format@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
+  integrity sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -5641,6 +5701,13 @@ globby@^8.0.1:
     pify "^3.0.0"
     slash "^1.0.0"
 
+good-listener@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
+  integrity sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=
+  dependencies:
+    delegate "^3.1.2"
+
 got@^6.7.1:
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
@@ -5959,6 +6026,11 @@ hast-util-is-element@^1.0.0:
   resolved "https://registry.yarnpkg.com/hast-util-is-element/-/hast-util-is-element-1.0.2.tgz#c23c9428b6a5a4e323bf9e16f87417476314981b"
   integrity sha512-4MEtyofNi3ZunPFrp9NpTQdNPN24xvLX3M+Lr/RGgPX6TLi+wR4/DqeoyQ7lwWcfUp4aevdt4RR0r7ZQPFbHxw==
 
+hast-util-parse-selector@^2.0.0:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-2.2.4.tgz#60c99d0b519e12ab4ed32e58f150ec3f61ed1974"
+  integrity sha512-gW3sxfynIvZApL4L07wryYF4+C9VvH3AUi7LAnVXV4MneGEgwOByXvFo18BgmTWnm7oHAe874jKbIB1YhHSIzA==
+
 hast-util-parse-selector@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-2.2.1.tgz#4ddbae1ae12c124e3eb91b581d2556441766f0ab"
@@ -6020,10 +6092,25 @@ hastscript@^4.0.0:
     property-information "^4.0.0"
     space-separated-tokens "^1.0.0"
 
+hastscript@^5.0.0:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-5.1.2.tgz#bde2c2e56d04c62dd24e8c5df288d050a355fb8a"
+  integrity sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==
+  dependencies:
+    comma-separated-tokens "^1.0.0"
+    hast-util-parse-selector "^2.0.0"
+    property-information "^5.0.0"
+    space-separated-tokens "^1.0.0"
+
 hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
+
+highlight.js@^10.1.1, highlight.js@~10.1.0:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.1.2.tgz#c20db951ba1c22c055010648dfffd7b2a968e00c"
+  integrity sha512-Q39v/Mn5mfBlMff9r+zzA+gWxRsCRKwEMvYTiisLr/XUiFI/4puWt0Ojdko3R3JCNWGdOWaA5g/Yxqa23kC5AA==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -6105,6 +6192,16 @@ html-react-parser@^0.6.4:
     react-dom-core "0.0.4"
     style-to-object "0.2.2"
 
+html-to-react@^1.3.4:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/html-to-react/-/html-to-react-1.4.3.tgz#1430a1cb581ef29533892ec70a2fdc4554b17ffd"
+  integrity sha512-txe09A3vxW8yEZGJXJ1is5gGDfBEVACmZDSgwDyH5EsfRdOubBwBCg63ZThZP0xBn0UE4FyvMXZXmohusCxDcg==
+  dependencies:
+    domhandler "^3.0"
+    htmlparser2 "^4.1.0"
+    lodash.camelcase "^4.3.0"
+    ramda "^0.27"
+
 html-void-elements@^1.0.0, html-void-elements@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-1.0.3.tgz#956707dbecd10cf658c92c5d27fee763aa6aa982"
@@ -6133,6 +6230,16 @@ htmlparser2@^3.10.0, htmlparser2@^3.3.0:
     entities "^1.1.1"
     inherits "^2.0.1"
     readable-stream "^3.1.1"
+
+htmlparser2@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-4.1.0.tgz#9a4ef161f2e4625ebf7dfbe6c0a2f52d18a59e78"
+  integrity sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^3.0.0"
+    domutils "^2.0.0"
+    entities "^2.0.0"
 
 http-cache-semantics@3.8.1:
   version "3.8.1"
@@ -7368,6 +7475,11 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
+
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
@@ -7521,6 +7633,14 @@ lowercase-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
   integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
 
+lowlight@^1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/lowlight/-/lowlight-1.14.0.tgz#83ebc143fec0f9e6c0d3deffe01be129ce56b108"
+  integrity sha512-N2E7zTM7r1CwbzwspPxJvmjAbxljCPThTFawEX2Z7+P3NGrrvY54u8kyU16IY4qWfoVIxY8SYCS8jTkuG7TqYA==
+  dependencies:
+    fault "^1.0.0"
+    highlight.js "~10.1.0"
+
 lpad-align@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/lpad-align/-/lpad-align-1.1.2.tgz#21f600ac1c3095c3c6e497ee67271ee08481fe9e"
@@ -7624,6 +7744,13 @@ md5@^2.2.1:
     charenc "~0.0.1"
     crypt "~0.0.1"
     is-buffer "~1.1.1"
+
+mdast-add-list-metadata@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-add-list-metadata/-/mdast-add-list-metadata-1.0.1.tgz#95e73640ce2fc1fa2dcb7ec443d09e2bfe7db4cf"
+  integrity sha512-fB/VP4MJ0LaRsog7hGPxgOrSL3gE/2uEdZyDuSEnKCv/8IkYHiDkIQSbChiJoHyxZZXZ9bzckyRk+vNxFzh8rA==
+  dependencies:
+    unist-util-visit-parents "1.1.2"
 
 mdast-util-compact@^1.0.0:
   version "1.0.2"
@@ -8714,6 +8841,18 @@ parse-entities@^1.0.2, parse-entities@^1.1.0:
     is-decimal "^1.0.0"
     is-hexadecimal "^1.0.0"
 
+parse-entities@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-2.0.0.tgz#53c6eb5b9314a1f4ec99fa0fdf7ce01ecda0cbe8"
+  integrity sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
+
 parse-filepath@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/parse-filepath/-/parse-filepath-1.0.2.tgz#a632127f53aaf3d15876f5872f3ffac763d6c891"
@@ -9686,6 +9825,13 @@ pretty-error@^2.1.1:
     renderkid "^2.0.1"
     utila "~0.4"
 
+prismjs@^1.21.0, prismjs@~1.21.0:
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.21.0.tgz#36c086ec36b45319ec4218ee164c110f9fc015a3"
+  integrity sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==
+  optionalDependencies:
+    clipboard "^2.0.0"
+
 private@^0.1.6:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -9755,6 +9901,13 @@ property-information@^4.0.0:
   integrity sha512-TlgDPagHh+eBKOnH2VYvk8qbwsCG/TAJdmTL7f1PROUcSO8qt/KSmShEQ/OKvock8X9tFjtqjCScyOkkkvIKVQ==
   dependencies:
     xtend "^4.0.1"
+
+property-information@^5.0.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-5.5.0.tgz#4dc075d493061a82e2b7d096f406e076ed859943"
+  integrity sha512-RgEbCx2HLa1chNgvChcx+rrCWD0ctBmGSE0M7lVm1yyv4UbvbrWoXp/BkVLZefzjrRBGW8/Js6uh/BnlHXFyjA==
+  dependencies:
+    xtend "^4.0.0"
 
 proto-list@~1.2.1:
   version "1.2.4"
@@ -9893,6 +10046,11 @@ querystringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.0.tgz#7ded8dfbf7879dcc60d0a644ac6754b283ad17ef"
   integrity sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==
 
+ramda@^0.27:
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
+  integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==
+
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -10029,10 +10187,29 @@ react-is@^16.7.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.3.tgz#4ad8b029c2a718fc0cfc746c8d4e1b7221e5387d"
   integrity sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==
 
+react-is@^16.8.6:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-markdown@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-4.3.1.tgz#39f0633b94a027445b86c9811142d05381300f2f"
+  integrity sha512-HQlWFTbDxTtNY6bjgp3C3uv1h2xcjCSi1zAEzfBW9OwJJvENSYiLXWNXN5hHLsoqai7RnZiiHzcnWdXk2Splzw==
+  dependencies:
+    html-to-react "^1.3.4"
+    mdast-add-list-metadata "1.0.1"
+    prop-types "^15.7.2"
+    react-is "^16.8.6"
+    remark-parse "^5.0.0"
+    unified "^6.1.5"
+    unist-util-visit "^1.3.0"
+    xtend "^4.0.1"
 
 react-side-effect@^1.1.0:
   version "1.1.5"
@@ -10041,6 +10218,17 @@ react-side-effect@^1.1.0:
   dependencies:
     exenv "^1.2.1"
     shallowequal "^1.0.1"
+
+react-syntax-highlighter@^13.3.1:
+  version "13.3.1"
+  resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-13.3.1.tgz#80cf556902859238628b1b9c2d6e28d5d396adb8"
+  integrity sha512-GfIduBKlc7oebsEU4dpJPo04kVTEhSxe9F9hGWrzYVgGssJ06Kmf74LVOPp6pzj0Tj5pr5en8SKI8H2al4XeRA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    highlight.js "^10.1.1"
+    lowlight "^1.14.0"
+    prismjs "^1.21.0"
+    refractor "^3.0.0"
 
 react@15:
   version "15.6.2"
@@ -10189,6 +10377,15 @@ redux@^4.0.0:
   dependencies:
     loose-envify "^1.4.0"
     symbol-observable "^1.2.0"
+
+refractor@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/refractor/-/refractor-3.1.0.tgz#b05a43c8a1b4fccb30001ffcbd5cd781f7f06f78"
+  integrity sha512-bN8GvY6hpeXfC4SzWmYNQGLLF2ZakRDNBkgCL0vvl5hnpMrnyURk8Mv61v6pzn4/RBHzSWLp44SzMmVHqMGNww==
+  dependencies:
+    hastscript "^5.0.0"
+    parse-entities "^2.0.0"
+    prismjs "~1.21.0"
 
 regenerate-unicode-properties@^8.0.2:
   version "8.0.2"
@@ -10676,6 +10873,11 @@ select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=
+
+select@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
+  integrity sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=
 
 selfsigned@^1.9.1:
   version "1.10.4"
@@ -11662,6 +11864,11 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
+tiny-emitter@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
+  integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
+
 tinycolor2@^1.1.2, tinycolor2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
@@ -12026,6 +12233,11 @@ unist-util-visit-children@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/unist-util-visit-children/-/unist-util-visit-children-1.1.2.tgz#bd78b53db9644b9c339ac502854f15471f964f5b"
   integrity sha512-q4t6aprUcSQ2/+xlswuh2wUKwUUuMmDjSkfwkMjeVwCXc8NqX8g0FSmNf68CznCmbkrsOPDUR0wj14bCFXXqbA==
+
+unist-util-visit-parents@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz#f6e3afee8bdbf961c0e6f028ea3c0480028c3d06"
+  integrity sha512-yvo+MMLjEwdc3RhhPYSximset7rwjMrdt9E41Smmvg25UQIenzrN83cRnF1JMzoMi9zZOQeYXHSDf7p+IQkW3Q==
 
 unist-util-visit-parents@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
Engineering blog entries need to be able to show code blocks. Markdown seems like the best way to do this along with a couple React components.

This PR adds `react-markdown` and `react-syntax-highlighter`. In Contentful, a new entry field `bodyMarkdown` was added.

<img width="1218" alt="image" src="https://user-images.githubusercontent.com/1479563/90285041-17b1f300-de41-11ea-966a-7415a299853d.png">
