### PR TITLE
Create dedicated pages for resource categories

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -53,6 +53,7 @@
 /blog/what_is_a_hipaa_baa.html /resources/what-is-a-hipaa-baa/
 /blog/windows-cli/ /changelog/windows-cli/
 /blog/y_combinator.html /blog/y-combinator/
+/blog/category/webinars/ /resources/webinars/
 /company/careers/ /company/
 /company/press/ /media/
 /company/resources/index.html /media/

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,6 +4,8 @@ const fs = require('fs');
 
 const BLOG_CATEGORIES = require('./src/data/blog-categories.json');
 const BLOG_POSTS_PER_PAGE = 5;
+const RESOURCE_CATEGORIES = require('./src/data/resource-categories.json');
+const resourceEntries = require('./src/data/resources.json');
 
 const COMPLIANCE_SITES = ['hipaa', 'gdpr'];
 let protocolData = {};
@@ -68,7 +70,11 @@ exports.createPages = ({ graphql, actions }) => {
         allWebinars: allContentfulWebinar {
           edges {
             node {
+              title
               slug
+              description {
+                description
+              }
             }
           }
         }
@@ -264,6 +270,29 @@ exports.createPages = ({ graphql, actions }) => {
           component: path.resolve(`./src/templates/resource.js`),
           context: {
             slug: node.slug
+          },
+        });
+      });
+
+      // Create pages resource categories
+      const webinarEntries = result.data.allWebinars.edges.map(({ node }) => {
+        return {
+          title: node.title,
+          url: `/webinars/${node.slug}/`,
+          description: node.description ? node.description.description : '',
+          tags: ['Webinar', node.webinarType ? 'On Demand' : 'Upcoming'],
+        }
+      });
+      RESOURCE_CATEGORIES.forEach((category) => {
+        createPage({
+          path: `resources/${category.slug}`,
+          component: path.resolve(`./src/templates/resource-category.js`),
+          context: {
+            title: category.title,
+            slug: category.slug,
+            entries: category.slug === 'webinars' ?
+              webinarEntries :
+              resourceEntries.filter((entry) => entry.tags.includes(category.title))
           },
         });
       });

--- a/src/components/resources/ResourceCards.js
+++ b/src/components/resources/ResourceCards.js
@@ -1,78 +1,55 @@
 import React from 'react';
+import { Link } from 'gatsby';
+import categories from '../../data/resource-categories.json';
 import { Grid } from '../grid/Grid';
 import styles from './ResourceCards.module.css';
 import ResourceCard from './ResourceCard';
 
-const FILTERS = {
-  ALL: "All",
-  GUIDES: "Guides",
-  WEBINAR: "Webinar",
-  DEPLOY: "Deploy"
-};
+const ResourceCards = ({ resources, categorySlug }) => {
+  const halfwayThrough = Math.floor(resources.length / 2)
+  const leftResources = resources.slice(0, halfwayThrough);
+  const rightResources = resources.slice(halfwayThrough, resources.length);
 
-class ResourceCards extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      activeFilter: FILTERS.ALL,
-    };
-  }
+  return (
+    <div className={styles.container}>
+      <Grid>
+        <div className={styles.left}>
+          <div className={styles.navigation}>
+            <h6 className="small">Resources</h6>
 
-  filterResources = (event) => {
-    this.setState({
-      activeFilter: event.target.textContent,
-    });
-  }
+            <Link
+              className={categorySlug === '' ? styles.active : ""}
+              to="/resources/"
+            >
+              All
+            </Link>
 
-  render() {
-    const { resources } = this.props;
-    const { activeFilter } = this.state;
-
-    let filteredResources = resources;
-    filteredResources = filteredResources.filter(item => {
-      if (activeFilter === FILTERS.ALL) {
-        return resources;
-      }
-
-      return item.tags.includes(activeFilter.replace(/s$/, "")); 
-    });
-    
-    const halfwayThrough = Math.floor(filteredResources.length / 2)
-    const leftResources = filteredResources.slice(0, halfwayThrough);
-    const rightResources = filteredResources.slice(halfwayThrough, filteredResources.length);
-
-    return (
-      <div className={styles.container}>
-        <Grid>
-          <div className={styles.left}>
-            <div className={styles.navigation}>
-              <h6 className="small">Resources</h6>
-
-              {Object.values(FILTERS).map(filter => (
-                <button
-                  key={filter}
-                  onClick={this.filterResources}
-                  className={activeFilter === filter ? styles.active : ""}
+            {categories.map((category) => {
+              return (
+                <Link
+                  className={categorySlug === category.slug ? styles.active : ""}
+                  to={`/resources/${category.slug}/`}
+                  key={category.slug}
                 >
-                  {filter}
-                </button>
-              ))}
-            </div>
-
-            {leftResources.map(resource => (
-              <ResourceCard key={resource.url} resource={resource} />
-            ))}
+                  {category.title}{category.title !== 'Deploy' ? 's' : ''}
+                </Link>
+              );
+            })}
           </div>
 
-          <div className={styles.right}>
-            {rightResources.map(resource => (
-              <ResourceCard key={resource.url} resource={resource} />
-            ))}
-          </div>
-        </Grid>
-      </div>
-    );
-  }
-}
+          {leftResources.map(resource => (
+            <ResourceCard key={resource.url} resource={resource} />
+          ))}
+        </div>
+
+        <div className={styles.right}>
+          {rightResources.map(resource => (
+            <ResourceCard key={resource.url} resource={resource} />
+          ))}
+        </div>
+      </Grid>
+    </div>
+  );
+};
 
 export default ResourceCards;

--- a/src/components/resources/ResourceCards.module.css
+++ b/src/components/resources/ResourceCards.module.css
@@ -14,7 +14,7 @@
   margin-bottom: 40px;
 }
 
-.navigation button {
+.navigation a {
   cursor: pointer;
   position: relative;
   font-size: 16px;
@@ -24,20 +24,22 @@
   border: 0;
   color: var(--white-fifty);
   padding: 0;
-}
-
-.navigation button:hover,
-.navigation button:focus,
-.navigation button:active,
-.navigation button.active {
+  text-decoration: none;
   color: white;
 }
 
-.navigation button:focus {
+.navigation a:hover,
+.navigation a:focus,
+.navigation a:active,
+.navigation a.active {
+  color: var(--white-fifty);
+}
+
+.navigation a:focus {
   outline: none;
 }
 
-.navigation button.active::after {
+.navigation a.active::after {
   content: "";
   display: block;
   position: absolute;
@@ -90,7 +92,7 @@
     margin-bottom: 20px;
   }
 
-  .navigation button {
+  .navigation a {
     font-size: 14px;
   }
 }

--- a/src/data/blog-categories.json
+++ b/src/data/blog-categories.json
@@ -1,9 +1,5 @@
 [
   {
-    "title": "Webinars",
-    "slug": "webinars"
-  },
-  {
     "title": "News & Updates",
     "slug": "news-updates"
   },

--- a/src/data/resource-categories.json
+++ b/src/data/resource-categories.json
@@ -1,0 +1,14 @@
+[
+  {
+    "title": "Deploy",
+    "slug": "deploy"
+  },
+  {
+    "title": "Guide",
+    "slug": "guides"
+  },
+  {
+    "title": "Webinar",
+    "slug": "webinars"
+  }
+]

--- a/src/pages/resources.js
+++ b/src/pages/resources.js
@@ -22,9 +22,11 @@ export default ({ data }) => {
         <title>Aptible | Security Management Resources</title>
         <meta name="description" content="Resources to help security teams maintain compliance and improve security management programs. Learn more." />
       </Helmet>
-
       <Introduction />
-      <ResourceCards resources={[...resources, ...webinars]} />
+      <ResourceCards
+        resources={[...resources, ...webinars]}
+        categorySlug=""
+      />
     </AptibleLayout>
   )
 };

--- a/src/templates/resource-category.js
+++ b/src/templates/resource-category.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import AptibleLayout from '../components/layouts/AptibleLayout';
+import Introduction from '../components/resources/Introduction';
+import ResourceCards from '../components/resources/ResourceCards';
+
+export default ({ pageContext }) => {
+  const { title, slug, entries } = pageContext;
+
+  return (
+    <AptibleLayout>
+      <Helmet>
+        <title>Aptible | Security Management Resources | {title}</title>
+        <meta name="description" content="Resources to help security teams maintain compliance and improve security management programs. Learn more." />
+      </Helmet>
+      <Introduction />
+      <ResourceCards
+        resources={entries}
+        categorySlug={slug}
+    />
+    </AptibleLayout>
+  )
+};


### PR DESCRIPTION
https://aptible.atlassian.net/browse/WWW-21
https://aptible.atlassian.net/browse/WWW-22

This PR creates subpages for resource categories Deploy, Guides and Webinars. The filtering buttons are now links and navigate to a page instead of changing the state on the page.

```
/resources/deploy/
/resources/guides/
/resources/webinars/
```

It also removes the webinar blog category and adds a redirect.