### PR TITLE
Fix bug in blog where list text is larger

### DIFF
--- a/src/components/blog/Post.module.css
+++ b/src/components/blog/Post.module.css
@@ -51,8 +51,15 @@
   margin: 60px 0 30px 0;
 }
 
-.body p {
+.body p,
+.body ul,
+.body ol {
   line-height: 1.6;
+}
+
+.body li > p {
+  display: contents;
+  margin: 0;
 }
 
 .body blockquote {

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -77,7 +77,9 @@ h6.small {
 }
 
 p,
-table {
+table,
+ul,
+ol {
   font-size: 16px;
   letter-spacing: 0.03em;
   line-height: 1.5;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1479563/91225628-ef07e400-e6f1-11ea-94e8-f00df2e03f1a.png)

This sets the global font size of `ul` and `ol` to match `p`.

It also finds `p` that are nested inside `li` and essential removes the `p` container. Margin is reset also. This removes extra space between list items.

<img width="821" alt="Screen Shot 2020-08-25 at 4 45 06 PM" src="https://user-images.githubusercontent.com/1479563/91225996-69386880-e6f2-11ea-9abb-12eb576ed469.png">
