### PR TITLE
Make webinarType available to webinar entries in resource-category.js

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -73,6 +73,7 @@ exports.createPages = ({ graphql, actions }) => {
             node {
               title
               slug
+              webinarType
               description {
                 description
               }


### PR DESCRIPTION
Fixes a bug on https://www.aptible.com/resources/webinars where all webinars were showing as "Upcoming" even though they were marked "On Demand" in Contentful.