### PR TITLE
Fix dead links to certifications

### DIFF
--- a/src/markdown/legal/privacy.md
+++ b/src/markdown/legal/privacy.md
@@ -235,13 +235,13 @@ To exercise any of these options, or for additional information about our privac
 
 Unfortunately, no data transmission over the Internet or data storage system can be guaranteed to be 100% secure. That said, we certainly try very hard, employing a variety of organizational, technical and administrative measures to provide a level of security appropriate to the risk associated with the personal information you trust us with. 
 
-To that end, we manage our data protection program consistent with ISO 27001, SOC 2, HITRUST, and applicable legal and regulatory requirements such as HIPAA and GDPR.
+To that end, we manage our data protection program consistent with ISO 27001, SOC 2, HITRUST, and applicable legal and regulatory requirements such as HIPAA and GDPR. Aptible's security reports and certifications can be accessed under NDA via Aptible's Comply Room; [click here](https://comply-grc.aptible.com/datarooms/ad352ac5-7d3b-4097-a1ac-894e34b4cba9) to request access. The list of documents includes the following:
 
-  * Aptible’s ISO 27001 certification for Aptible Deploy and Aptible Comply is available [here](/compliance/iso-27001-certification/).
+  * Aptible’s ISO 27001 certification for Aptible Deploy and Aptible Comply
 
-  * Aptible’s HITRUST CSF stand-alone certification letter is available [here](/compliance/hitrust-csf-certification/).
+  * Aptible’s HITRUST CSF stand-alone certification letter
 
-  * Aptible’s current SOC 2 Type 2 report and HITRUST CSF Validated Assessment Report are available under NDA to customers only (please contact [support@aptible.com][2] for copies)
+  * Aptible’s current SOC 2 Type 2 report and HITRUST CSF Validated Assessment Report
 
 Please see our [Security Policy][3] for more details.
 

--- a/src/markdown/legal/security.md
+++ b/src/markdown/legal/security.md
@@ -179,10 +179,10 @@ Aptible monitors the stability and availability of customer infrastructure and a
 We do not access or use Your Content for any purpose other than for developing and operating the Services and as required by law. As a routine matter, Aptible workforce members do not require access to data processed by your Aptible Deploy Containerized Services, such as data stored in your databases. Aptible workforce members are granted least-privilege access to customer environments only when a specific business need arises. Workforce members undergo criminal background screening before hire. In some cases, such as Aptible Deploy databases, you may encrypt Your Content using keys you manage.
 
 ##### **5.B - Security Management**
-Aptible manages information security consistent with ISO 27001, SOC 2, HITRUST, and applicable legal and regulatory requirements such as HIPAA and GDPR. 
+Aptible manages information security consistent with ISO 27001, SOC 2, HITRUST, and applicable legal and regulatory requirements such as HIPAA and GDPR. Aptible's security reports and certifications can be accessed under NDA via Aptible's Comply Room; [click here](https://comply-grc.aptible.com/datarooms/ad352ac5-7d3b-4097-a1ac-894e34b4cba9) to request access. The list of documents includes the following:
 
-- Aptible's [ISO 27001 certification for Aptible Deploy and Gridron is available here](/compliance/iso-27001-certification/). 
-- You can view Aptible's [HITRUST CSF standalone certification letter here](/compliance/hitrust-csf-certification/). 
-- Aptible's current SOC 2 Type 2 report and HITRUST CSF Validated Assessment Report are available under NDA, please [contact us].
+- Aptible's ISO 27001 certification for Aptible Deploy and Gridron 
+- Aptible's HITRUST CSF standalone certification letter
+- Aptible's current SOC 2 Type 2 report and HITRUST CSF Validated Assessment Report
 
 We also run a [responsible disclosure program](/legal/responsible-disclosure) for security vulnerabilities, with cash bounties.

--- a/src/markdown/legal/security.md
+++ b/src/markdown/legal/security.md
@@ -181,8 +181,8 @@ We do not access or use Your Content for any purpose other than for developing a
 ##### **5.B - Security Management**
 Aptible manages information security consistent with ISO 27001, SOC 2, HITRUST, and applicable legal and regulatory requirements such as HIPAA and GDPR. Aptible's security reports and certifications can be accessed under NDA via Aptible's Comply Room; [click here](https://comply-grc.aptible.com/datarooms/ad352ac5-7d3b-4097-a1ac-894e34b4cba9) to request access. The list of documents includes the following:
 
-- Aptible's ISO 27001 certification for Aptible Deploy and Gridron 
-- Aptible's HITRUST CSF standalone certification letter
+- Aptible's ISO 27001 certification for Aptible Deploy and Aptible Comply 
+- Aptible's HITRUST CSF stand-alone certification letter
 - Aptible's current SOC 2 Type 2 report and HITRUST CSF Validated Assessment Report
 
 We also run a [responsible disclosure program](/legal/responsible-disclosure) for security vulnerabilities, with cash bounties.


### PR DESCRIPTION
Now available via our Comply Room.
A customer raised this in https://aptible.zendesk.com/agent/tickets/28592