### PR TITLE
rm presenter1 from webinar

### DIFF
--- a/src/templates/webinar.js
+++ b/src/templates/webinar.js
@@ -27,15 +27,6 @@ export const query = graphql`
       body {
         json
       }
-      presenter1 {
-        name
-        jobTitle
-        professionalPhoto {
-          file {
-            url
-          }
-        }
-      }
       presenter2 {
         name
         jobTitle


### PR DESCRIPTION
Fixes errors:

```
ERROR  Failed to compile with 1 errors                                                                                                                                                                                                             10:06:54 AM

 error  in ./src/templates/webinar.js

Module Error (from ./node_modules/eslint-loader/index.js):

/Users/ericbower/work/www/src/templates/webinar.js
  30:7  error  Cannot query field "presenter1" on type "ContentfulWebinar". Did you mean "presenter2"?  graphql/template-strings

✖ 1 problem (1 error, 0 warnings)


 @ ./.cache/sync-requires.js 21:60-121
 @ ./.cache/app.js
 @ multi event-source-polyfill (webpack)-hot-middleware/client.js?path=/__webpack_hmr&reload=true&overlay=false ./.cache/app

✖ ｢wdm｣:
ERROR in ./src/templates/webinar.js
Module Error (from ./node_modules/eslint-loader/index.js):

/Users/ericbower/work/www/src/templates/webinar.js
  30:7  error  Cannot query field "presenter1" on type "ContentfulWebinar". Did you mean "presenter2"?  graphql/template-strings

✖ 1 problem (1 error, 0 warnings)

 @ ./.cache/sync-requires.js 21:60-121
 @ ./.cache/app.js
 @ multi event-source-polyfill (webpack)-hot-middleware/client.js?path=/__webpack_hmr&reload=true&overlay=false ./.cache/app
ℹ ｢wdm｣: Failed to compile.

```