### PR TITLE
Temporarily redirect /security to /legal/security

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -89,6 +89,7 @@ http {
     rewrite ^/resources/enclave-reference-architecture/?$ /assets/deploy-reference-architecture.pdf permanent;
     rewrite ^/comply/workflows/?$ https://conveyorhq.com permanent;
     rewrite ^/signup-comply/?$ https://conveyorhq.com permanent;
+    rewrite ^/security/?$ /legal/security/ redirect;
 
     rewrite ^/documentation/?$  https://deploy-docs.aptible.com/ permanent;
     rewrite ^/support/?$  https://deploy-docs.aptible.com/ permanent;
@@ -341,7 +342,7 @@ http {
     rewrite ^/integrations/aws/?$ https://conveyorhq.com/integrations/aws permanent;
     rewrite ^/integrations/addigy/?$ https://conveyorhq.com/integrations/addigy permanent;
     rewrite ^/integrations/airwatch/?$ https://conveyorhq.com/integrations/airwatch permanent;
-    rewrite ^a/integrations/ptible-deploy/?$ https://conveyorhq.coma/integrations/ptible-deploy permanent;
+    rewrite ^/integrations/aptible-deploy/?$ https://conveyorhq.com/integrations/aptible-deploy permanent;
     rewrite ^/integrations/bitbucket/?$ https://conveyorhq.com/integrations/bitbucket permanent;
     rewrite ^/integrations/custom-integrations/?$ https://conveyorhq.com/integrations/custom-integrations permanent;
     rewrite ^/integrations/gcp/?$ https://conveyorhq.com/integrations/gcp permanent;


### PR DESCRIPTION
Context: [Slack thread](https://aptible-support.slack.com/archives/C025D8EALCT/p1624922642003800)

Also fixed (I think) a typo in a separate redirect rule. That said, @almathew it seems like this and many other pages don't actually exist on conveyorhq.com. No immediate action required, but we should be able to remove the rules from nginx.conf to keep it a bit slimmer.