### PR TITLE
hipaa form fix

### DIFF
--- a/src/hooks/use-form-completion.js
+++ b/src/hooks/use-form-completion.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 export const useFormCompletion = item => {
-  const [completed, setCompleted] = useState(localStorage.getItem(item));
+  const [completed, setCompleted] = useState(false);
 
   useEffect(() => {
     setCompleted(localStorage.getItem(item));


### PR DESCRIPTION
This should fix the localStorage not found issue.  Basically at build time, gatsby tries to build as much html as possible but because we are trying to use local storage and that is not available in node so it fails.  Since our other calls of localStorage are behind `useEffect` it should not affect the build step.