### PR TITLE
Fix HIPAA bypass for production

### DIFF
--- a/src/components/hipaa-gated-form/index.js
+++ b/src/components/hipaa-gated-form/index.js
@@ -1,17 +1,17 @@
 import React from 'react';
-import * as queryString from 'query-string';
 import { useFormCompletion } from '../../hooks/use-form-completion';
+import { useQueryParam } from '../../hooks/use-query-param';
 import pic from '../../images/security-management/sm1.jpg';
-import { querystring } from '../../lib/util';
+
 import LeadForm from '../lead-form';
 import Modal, { ModalView } from '../modal';
 
 import styles from './hipaa.module.css';
 
 export default () => {
-  const queryParams = queryString.parse(querystring());
-  const bypass = !!queryParams.bypass;
   const { completed, onComplete } = useFormCompletion('hipaa-guide');
+  const { bypass } = useQueryParam('bypass');
+
   if (completed || bypass) return null;
 
   return (

--- a/src/hooks/use-query-param.js
+++ b/src/hooks/use-query-param.js
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react';
+import * as queryString from 'query-string';
+import { querystring } from '../lib/util';
+
+export const useQueryParam = paramName => {
+  const queryParams = queryString.parse(querystring());
+  const [param, setParam] = useState(null);
+
+  useEffect(() => {
+    setParam(queryParams[paramName]);
+  }, [param]);
+
+  return { [paramName]: param };
+};


### PR DESCRIPTION
in #202 I implemented a query param check that allows users to bypass the HIPAA Guide's lead capture gate. Unfortunately, my implementation in the previous PR didn't account for a difference in how production Gatsby builds render and as a result doesn't actually work in prod (though it does in development)

This PR fixes the gate bypass for production builds by wrapping the query param check in a useEffect hook.

