### PR TITLE
Demo Schedule Page

### DIFF
--- a/src/components/aws-activate-form/ActivateForm.js
+++ b/src/components/aws-activate-form/ActivateForm.js
@@ -51,6 +51,7 @@ export const ActivateForm = ({
   const [website, setWebsite] = useState('');
   const [requirements, setRequirements] = useState('');
   const [currentHost, setCurrentHost] = useState('');
+  const [useCase, setUseCase] = useState('');
   const [error, setError] = useState('');
   const queryParams = queryString.parse(querystring());
 
@@ -109,13 +110,13 @@ export const ActivateForm = ({
           target="captureFrame"
           className={styles.leadForm}
         >
-          <h3>Submit Your Application</h3>
+          <h5>Submit Your Application</h5>
 
           {injectedQueryParams.map(k => (
             <input hidden name={k} key={k} value={queryParams[k]} />
           ))}
 
-          <p className="L">
+          <p className="">
             Please complete the application form below. Someone from Aptible
             will reach out to discuss next steps once your application has been
             received.
@@ -163,6 +164,7 @@ export const ActivateForm = ({
               name="Company Website"
             />
           </div>
+
           <div className={cn(styles.inputGroup, styles.verticalInputGroup)}>
             <label>Current Hosting Provider:</label>
             <input
@@ -171,6 +173,17 @@ export const ActivateForm = ({
               onChange={e => setCurrentHost(e.target.value)}
               type="text"
               name="Current Hosting Provider"
+            />
+          </div>
+
+          <div className={cn(styles.inputGroup, styles.verticalInputGroup)}>
+            <label>What's prompting you to try Aptible?</label>
+            <input
+              required
+              className={styles.leadFormInput}
+              onChange={e => setUseCase(e.target.value)}
+              type="text"
+              name="Use Case"
             />
           </div>
 
@@ -212,16 +225,18 @@ export const ActivateForm = ({
             ))}
           </div>
 
-          <button
-            className={cn(buttonStyles.button, styles.button)}
-            type="submit"
-          >
-            {btnText}
-          </button>
+          <div className={styles.actions}>
+            <button
+              className={cn(buttonStyles.button, styles.button)}
+              type="submit"
+            >
+              {btnText}
+            </button>
 
-          <button type="cancel" className={styles.cancel} onClick={onCancel}>
-            Cancel
-          </button>
+            <button type="cancel" className={styles.cancel} onClick={onCancel}>
+              Cancel
+            </button>
+          </div>
 
           {disclaimer && (
             <p class="S">{disclaimer}</p>

--- a/src/components/aws-activate-form/ActivateForm.js
+++ b/src/components/aws-activate-form/ActivateForm.js
@@ -49,7 +49,6 @@ export const ActivateForm = ({
   const [email, setEmail] = useState('');
   const [company, setCompany] = useState('');
   const [website, setWebsite] = useState('');
-  const [requirements, setRequirements] = useState('');
   const [currentHost, setCurrentHost] = useState('');
   const [useCase, setUseCase] = useState('');
   const [error, setError] = useState('');
@@ -68,8 +67,8 @@ export const ActivateForm = ({
       email,
       company,
       website,
-      requirements,
       currentHost,
+      useCase
     });
     setSubmitted(true);
     setError('');
@@ -90,6 +89,7 @@ export const ActivateForm = ({
       </Helmet>
 
       <iframe
+        title="AWS Activate Capture Form"
         name="captureFrame"
         height="0"
         width="0"

--- a/src/components/aws-activate-form/ActivateForm.module.css
+++ b/src/components/aws-activate-form/ActivateForm.module.css
@@ -99,7 +99,7 @@
 
 .option {
   margin-right: 24px;
-  margin-bottom: 24px;
+  margin-bottom: 8px;
 }
 
 .options label {
@@ -111,12 +111,20 @@
   margin-top: 1px;
 }
 
+.actions {
+  display: flex;
+  flex-direction: row;
+}
+
+.actions button {
+  flex: 1;
+}
+
 .cancel {
   color: var(--white-seventy);
   background: none;
   border: none;
   padding: 0;
-  margin: 24px 0;
   display: block;
   cursor: pointer;
 }

--- a/src/components/deploy/Faq.js
+++ b/src/components/deploy/Faq.js
@@ -1,14 +1,5 @@
 import React from 'react';
-import { Grid } from '../grid/Grid';
 import styles from './Faq.module.css';
-import hipaaBadge from '../../images/home/badges/hipaa-24x24.svg';
-import hitrustBadge from '../../images/home/badges/hitrust-24x24.svg';
-import soc2Badge from '../../images/home/badges/soc-24x24.svg';
-import isoBadge from '../../images/home/badges/iso-24x24.svg';
-import dashboardIlly from '../../images/home/illustrations/deploy-container-metrics-dashboard.svg';
-import deployConsoleIlly from '../../images/home/illustrations/deploy-console.svg';
-import mobileHero from '../../images/home/illustrations/mobile-hero-dashboard.svg';
-import LeadForm from '../../components/lead-form';
 
 const Question = ({ title, question }) => {
   return (

--- a/src/components/deploy/Hero.js
+++ b/src/components/deploy/Hero.js
@@ -4,7 +4,6 @@ import styles from './Hero.module.css';
 import hipaaBadge from '../../images/home/badges/hipaa-24x24.svg';
 import hitrustBadge from '../../images/home/badges/hitrust-24x24.svg';
 import soc2Badge from '../../images/home/badges/soc-24x24.svg';
-import isoBadge from '../../images/home/badges/iso-24x24.svg';
 import dashboardIlly from '../../images/home/illustrations/deploy-container-metrics-dashboard.svg';
 import deployConsoleIlly from '../../images/home/illustrations/deploy-console.svg';
 import mobileHero from '../../images/home/illustrations/mobile-hero-dashboard.svg';
@@ -23,7 +22,7 @@ export const CompliancePills = () => {
 const CompliancePill = ({ title, svg }) => {
   return (
     <div className={styles.compliancePill}>
-      <img src={svg} className={styles.compliancePillBadge} />
+      <img alt={title} src={svg} className={styles.compliancePillBadge} />
       <h6 className="small">{title}</h6>
     </div>
   );
@@ -66,7 +65,7 @@ export default () => (
       </div>
 
       <div className={styles.illustration}>
-        <img src={mobileHero} className={styles.mobileHero} />
+        <img alt="Aptible Illustration" src={mobileHero} className={styles.mobileHero} />
         <img
           className={styles.containerMeticsDashboard}
           alt="Container Metrics Dashboard."
@@ -74,7 +73,7 @@ export default () => (
         />
         <img
           className={styles.containerDeploymentConsole}
-          alt="Image of console deploying a docker app on Aptible."
+          alt="Terminal deploying a docker app on Aptible."
           src={deployConsoleIlly}
         />
       </div>

--- a/src/components/deploy/SecurityControlTable.js
+++ b/src/components/deploy/SecurityControlTable.js
@@ -19,10 +19,10 @@ const Control = ({
       <p>{body}</p>
       <div className={styles.providedBy}>
         {provider === 'Aptible' && (
-          <img src={aptibleFavicon} className={styles.providedByImage} />
+          <img alt="aptible icon" src={aptibleFavicon} className={styles.providedByImage} />
         )}
         {provider === 'AWS' && (
-          <img src={awsFavicon} className={styles.providedByImage} />
+          <img alt="aws icon" src={awsFavicon} className={styles.providedByImage} />
         )}
         <p className="S">
           {category} provided by {provider}

--- a/src/components/deploy/SecurityControls.js
+++ b/src/components/deploy/SecurityControls.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { Grid } from '../grid/Grid';
 import styles from './SecurityControls.module.css';
 import awsLogo from '../../images/home/illustrations/aws-logo.png';
-import LeadForm from '../lead-form';
 
 export default () => (
   <div id="aptible-vs-aws" className={styles.container}>

--- a/src/components/deploy/Solutions.js
+++ b/src/components/deploy/Solutions.js
@@ -38,8 +38,8 @@ const Solution = ({
         </div>
       </div>
       <div className={styles.solutionFeatures}>
-        {features.map(feature => (
-          <Feature {...feature} />
+        {features.map((feature, idx) => (
+          <Feature {...feature} key={idx} />
         ))}
       </div>
     </div>

--- a/src/components/footer/Footer.js
+++ b/src/components/footer/Footer.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Link } from 'gatsby';
 import { Grid } from '../grid/Grid';
-import NewsletterSignup from './NewsletterSignup';
 import styles from './Footer.module.css';
 
 const twitterIcon = (

--- a/src/components/header/MainNavItem.js
+++ b/src/components/header/MainNavItem.js
@@ -24,9 +24,6 @@ function NavLink({ title, to }) {
 }
 
 function DropDown({ title, onClickFn, sectionName, openSectionName }) {
-  const url = typeof window !== 'undefined' ? window.location.href : '';
-  const isActive = url.toLowerCase().indexOf(sectionName.toLowerCase()) > -1;
-  const style = isActive ? { color: 'white' } : {};
   return (
     <div
       onClick={() => onClickFn(sectionName)}

--- a/src/components/lead-form/LeadForm.js
+++ b/src/components/lead-form/LeadForm.js
@@ -1,5 +1,6 @@
 import * as queryString from 'query-string';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { navigate } from 'gatsby'
 import { Helmet } from 'react-helmet';
 import cn from 'classnames';
 import styles from './LeadForm.module.css';
@@ -19,12 +20,15 @@ export const LeadForm = ({
   btnText = 'Get a demo',
   successText = 'Thanks! Our team will contact you to schedule a demo shortly.',
   inputPlaceholder = 'Enter your email',
+  scheduleDemoOnSubmit = true,
+  calendarId = 'frank-macreery',
   onSuccess = () => {},
 }) => {
   const [submitted, setSubmitted] = useState(false);
   const [email, setEmail] = useState('');
   const [error, setError] = useState('');
   const queryParams = queryString.parse(querystring());
+  const shouldShowSuccessMessage = !scheduleDemoOnSubmit && submitted;
 
   const onSubmit = () => {
     const result = validateEmail(email);
@@ -38,6 +42,10 @@ export const LeadForm = ({
     setError('');
     trackOnLinkedIn();
     onSuccess();
+
+    if (scheduleDemoOnSubmit) {
+      navigate(`/p/schedule-a-demo?calendar=${calendarId}`)
+    }
   };
 
   return (
@@ -70,7 +78,7 @@ export const LeadForm = ({
           className={styles.leadForm}
         >
           {utmKeywords.map(k => (
-            <input hidden name={k} key={k} value={queryParams[k]} />
+            <input hidden readOnly name={k} key={k} value={queryParams[k]} />
           ))}
           <input
             required
@@ -89,7 +97,7 @@ export const LeadForm = ({
         <div className={styles.error}>{error ? error : ''}</div>
       </div>
 
-      {submitted && (
+      {shouldShowSuccessMessage && (
         <div className={styles.submissionNotification}>{successText}</div>
       )}
     </div>

--- a/src/components/lead-form/LeadForm.js
+++ b/src/components/lead-form/LeadForm.js
@@ -1,5 +1,5 @@
 import * as queryString from 'query-string';
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { navigate } from 'gatsby'
 import { Helmet } from 'react-helmet';
 import cn from 'classnames';
@@ -61,6 +61,7 @@ export const LeadForm = ({
       </Helmet>
 
       <iframe
+        title="Lead Form"
         name="captureFrame"
         height="0"
         width="0"

--- a/src/components/pricing/Deploy.js
+++ b/src/components/pricing/Deploy.js
@@ -1,12 +1,8 @@
 import React from 'react';
 import styles from './Pricing.module.css';
-import PricingArrow from './PricingArrow';
 import CheckmarkUnorderedList from '../shared/CheckmarkUnorderedList';
-import PricingBlock from './PricingBlock';
 import DeployCalculator from './DeployCalculator';
 import SignupButton from '../signup/SignupButton';
-import detailsIcons from '../../images/pricing/details.svg';
-import detailsArrow from '../../images/arrows/header-resources.svg';
 
 class Deploy extends React.Component {
   constructor(props) {

--- a/src/components/pricing/Pricing.js
+++ b/src/components/pricing/Pricing.js
@@ -3,23 +3,15 @@ import { Grid } from '../grid/Grid';
 import styles from './Pricing.module.css';
 import Deploy from './Deploy';
 
-class Pricing extends React.Component {
-  constructor(props) {
-    super(props);
-  }
+const Pricing = () => (
+  <Grid>
+    <div className={styles.hero}>
+      <h1 className="XL">Aptible Pricing</h1>
+      <p className="XL">Plans that scale to meet your needs</p>
+    </div>
 
-  render() {
-    return (
-      <Grid>
-        <div className={styles.hero}>
-          <h1 className="XL">Aptible Pricing</h1>
-          <p className="XL">Plans that scale to meet your needs</p>
-        </div>
-
-        <Deploy />
-      </Grid>
-    );
-  }
-}
+    <Deploy />
+  </Grid>
+)
 
 export default Pricing;

--- a/src/components/prr-form/PrrForm.js
+++ b/src/components/prr-form/PrrForm.js
@@ -61,6 +61,7 @@ export const PrrForm = ({
       </Helmet>
 
       <iframe
+        title="Form Submission"
         name="captureFrame"
         height="0"
         width="0"

--- a/src/components/resources/ResourceCards.js
+++ b/src/components/resources/ResourceCards.js
@@ -1,6 +1,4 @@
 import React from 'react';
-import { Link } from 'gatsby';
-import categories from '../../data/resource-categories.json';
 import { Grid } from '../grid/Grid';
 import styles from './ResourceCards.module.css';
 import ResourceCard from './ResourceCard';

--- a/src/components/shared/Card.js
+++ b/src/components/shared/Card.js
@@ -6,8 +6,6 @@ import Arrow from '../shared/Arrow';
 import WistiaVideo from './WistiaVideo';
 import videoPlayIcon from '../../images/video-play.svg';
 import customerCards from '../../data/customer-cards.json';
-
-import quadpayPhoto from '../../images/customers/photos/quadpay-ian-yamey.jpg';
 import healthCatalystLogo from '../../images/customers/logos/health-catalyst.png';
 import ableHealthLogo from '../../images/customers/logos/able-health.png';
 import healthifyLogo from '../../images/customers/logos/healthify.svg';
@@ -58,7 +56,7 @@ const CardLogo = ({ logo, to, website, alt }) => {
   );
 
   if(website && !to) {
-    return <a href={website} target="_blank">{img}</a>
+    return <a href={website} target="_blank" rel="noopener noreferrer">{img}</a>
   }
   
   return img
@@ -150,8 +148,6 @@ class Card extends React.Component {
 
     const to = customerData.link;
     const image = photos[customer];
-    const ContainerElement = to ? Link : 'div';
-
     const cardContent = (
       <>
         {image && <CardMedia

--- a/src/html.js
+++ b/src/html.js
@@ -8,6 +8,26 @@ const segmentJs = `
   }}();
 `;
 
+const linkedIn = `
+  _linkedin_partner_id = "42067";
+  window._linkedin_data_partner_ids = window._linkedin_data_partner_ids || [];
+  window._linkedin_data_partner_ids.push(_linkedin_partner_id);
+  (function(l) {
+    if (!l) {
+      window.lintrk = function(a,b){
+        window.lintrk.q.push([a,b])
+      };
+      window.lintrk.q=[]
+    }
+    var s = document.getElementsByTagName("script")[0];
+    var b = document.createElement("script");
+    b.type = "text/javascript";
+    b.async = true;
+    b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
+    s.parentNode.insertBefore(b, s);
+  })(window.lintrk);
+`;
+
 const hotjarJs = `
   (function(h,o,t,j,a,r){
       h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
@@ -40,6 +60,7 @@ export default function HTML(props) {
           content="width=device-width, initial-scale=1, shrink-to-fit=no"
         />
         {props.headComponents}
+        <script dangerouslySetInnerHTML={{ __html: linkedIn }} />
         <script dangerouslySetInnerHTML={{ __html: segmentJs }} />
         <script dangerouslySetInnerHTML={{ __html: hotjarJs }} />
         <script dangerouslySetInnerHTML={{ __html: aptibleJs }} />

--- a/src/pages/p/VideoLandingPage.module.css
+++ b/src/pages/p/VideoLandingPage.module.css
@@ -94,6 +94,10 @@
   margin-bottom: 48px;
 }
 
+.meetingsFormWrapper {
+  width: 720px;
+}
+
 @media (--mobile) {
   .inputGroup,
   .headerText,

--- a/src/pages/p/VideoLandingPage.module.css
+++ b/src/pages/p/VideoLandingPage.module.css
@@ -130,4 +130,8 @@
   .inputGroup {
     width: 90%;
   }
+
+  .meetingsFormWrapper {
+    width: 100%;
+  }
 }

--- a/src/pages/p/aws-activate.js
+++ b/src/pages/p/aws-activate.js
@@ -1,11 +1,9 @@
 import React, { useState } from 'react';
-import { Link } from 'gatsby';
 import { Helmet } from 'react-helmet';
 import { Grid } from '../../components/grid/Grid';
 import cn from 'classnames';
 import Proof from '../../components/deploy/Proof';
 import AptibleLayout from '../../components/layouts/AptibleLayout';
-import Title from './components/Title';
 import buttonStyles from '../../components/buttons/Button.module.css';
 import ActivateForm from '../../components/aws-activate-form';
 import securityImage from '../../images/solutions/security-controls.svg';
@@ -21,9 +19,9 @@ import awsLogo from '../../images/aws-activate-logo.png'
 import styles from './AwsActivate.module.css';
 
 const RedeemButton = ({ setShowForm }) => (
-  <a onClick={() => setShowForm(true)} className={cn(buttonStyles.button)}>
+  <button onClick={() => setShowForm(true)} className={cn(buttonStyles.button)}>
     Redeem Free Credits Now
-  </a>
+  </button>
 );
 
 export default () => {
@@ -96,7 +94,7 @@ export default () => {
                   </p>
                 </>
               }
-              smallImage={<img width="50%" src={aptibleIcon} />}
+              smallImage={<img width="50%" alt="Aptible Icon" src={aptibleIcon} />}
               heroImage={
                 <img
                   src={securityImage}

--- a/src/pages/p/components/Testimonial.js
+++ b/src/pages/p/components/Testimonial.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import healthCatalystLogo from '../../../images/customers/logos/health-catalyst-color.png';
 import styles from '../VideoLandingPage.module.css';
@@ -11,7 +11,7 @@ export default () => {
         more people and we still would not have the high level of support and
         tooling that Aptible provides.”
       </h3>
-      <img src={healthCatalystLogo} className={styles.testimonialImage} />
+      <img src={healthCatalystLogo} alt="Health Catalyst logo" className={styles.testimonialImage} />
       <div>Mark Siemers, Software Engineering Manager</div>
     </div>
   );

--- a/src/pages/p/devsecops-la.js
+++ b/src/pages/p/devsecops-la.js
@@ -1,11 +1,9 @@
 import React, { useState } from 'react';
-import { Link } from 'gatsby';
 import { Helmet } from 'react-helmet';
 import { Grid } from '../../components/grid/Grid';
 import cn from 'classnames';
 import Proof from '../../components/deploy/Proof';
 import AptibleLayout from '../../components/layouts/AptibleLayout';
-import Title from './components/Title';
 import buttonStyles from '../../components/buttons/Button.module.css';
 import ActivateForm from '../../components/aws-activate-form';
 import securityImage from '../../images/solutions/security-controls.svg';
@@ -20,9 +18,9 @@ import Faq from '../../components/deploy/Faq';
 import styles from './AwsActivate.module.css';
 
 const RedeemButton = ({ setShowForm }) => (
-  <a onClick={() => setShowForm(true)} className={cn(buttonStyles.button)}>
+  <button onClick={() => setShowForm(true)} className={cn(buttonStyles.button)}>
     Redeem Now
-  </a>
+  </button>
 );
 
 export default () => {
@@ -78,7 +76,7 @@ export default () => {
                   </p>
                 </>
               }
-              smallImage={<img width="50%" src={aptibleIcon} />}
+              smallImage={<img width="50%" alt="Aptible icon" src={aptibleIcon} />}
               heroImage={
                 <img
                   src={securityImage}
@@ -151,7 +149,7 @@ export default () => {
                       <p className="">
                         Businesses have to show proof of DevSecOps Days 2021 attendance.
                         &nbsp;
-                        <a onClick={() => setShowForm(true)} href="#">
+                        <a href="" onClick={() => setShowForm(true)} href="#">
                           Submit your info
                         </a>{' '}
                         and a member of the Aptible team will reach out with

--- a/src/pages/p/production-readiness-review.js
+++ b/src/pages/p/production-readiness-review.js
@@ -9,9 +9,9 @@ import heroStyles from '../../components/deploy/Hero.module.css';
 import Modal, { ModalView } from '../../components/modal';
 
 const SignupButton = ({ setShowForm }) => (
-  <a onClick={() => setShowForm(true)} className={cn(buttonStyles.button)}>
+  <button onClick={() => setShowForm(true)} className={cn(buttonStyles.button)}>
     Start Your Production Readiness Review
-  </a>
+  </button>
 );
 
 export default () => {

--- a/src/pages/p/referral-program.js
+++ b/src/pages/p/referral-program.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Helmet } from 'react-helmet';
 import { Grid } from '../../components/grid/Grid';
 import AptibleLayout from '../../components/layouts/AptibleLayout';

--- a/src/pages/p/schedule-a-demo.js
+++ b/src/pages/p/schedule-a-demo.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import classnames from 'classnames';
+
+import Title from './components/Title';
+import { useQueryParam } from '../../hooks/use-query-param';
+import styles from './VideoLandingPage.module.css';
+
+const availableCalendars = {
+  'frank-macreery': 1,
+  'skylar-anderson': 1
+}
+
+const DEFAULT_CALENDAR = 'frank-macreery';
+
+const getCalendarIdFromQueryParam = (calendar) => {
+  return availableCalendars[calendar] ? calendar : DEFAULT_CALENDAR;
+}
+
+export default () => {
+  const { calendar } = useQueryParam('calendar');
+  const calendarId = getCalendarIdFromQueryParam(calendar);
+
+  return (
+    <div>
+      <Helmet>
+        <title>Aptible | Schedule a Demo</title>
+        <meta
+          name="description"
+          content="Go from zero to HITRUST-compliant Docker deployment in minutes"
+        />
+        <script
+          type="text/javascript"
+          src="//static.hsappstatic.net/MeetingsEmbed/ex/MeetingsEmbedCode.js"
+        />
+      </Helmet>
+      <div className={styles.layout}>
+        <div className={classnames(styles.container, styles.textCenter)}>
+          <Title
+            title="Schedule time with Aptible"
+            summary="Use the scheduler below to arrange a demo time with Aptible."
+          />
+
+          <div className={styles.meetingsFormWrapper}>
+            <div
+              className="meetings-iframe-container"
+              data-src={`https://meetings.hubspot.com/${calendarId}?embed=true`}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/resources.js
+++ b/src/pages/resources.js
@@ -6,15 +6,15 @@ import ResourceCards from '../components/resources/ResourceCards';
 import resources from '../data/resources.json';
 
 export default ({ data }) => {
-  const webinars = data.posts.edges.map(webinar => {
-    const { node } = webinar;
-    return {
-      title: node.title,
-      url: `/webinars/${node.slug}/`,
-      description: node.description ? node.description.description : '',
-      tags: ['Webinar', node.webinarType ? 'On Demand' : 'Upcoming'],
-    };
-  });
+  // const webinars = data.posts.edges.map(webinar => {
+  //   const { node } = webinar;
+  //   return {
+  //     title: node.title,
+  //     url: `/webinars/${node.slug}/`,
+  //     description: node.description ? node.description.description : '',
+  //     tags: ['Webinar', node.webinarType ? 'On Demand' : 'Upcoming'],
+  //   };
+  // });
 
   return (
     <AptibleLayout>

--- a/src/pages/solutions/components/Feature.js
+++ b/src/pages/solutions/components/Feature.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import styles from './Feature.module.css';
-import cn from 'classnames';
 import StepByStep from '../../../components/deploy/StepByStep';
 
 export default ({ title, description, smallImage, heroImage, steps }) => (

--- a/src/pages/solutions/components/Testimonial.js
+++ b/src/pages/solutions/components/Testimonial.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import styles from './Testimonial.module.css';
-import cn from 'classnames';
 
 export default ({ quote, author, title, company, url, logo, image }) => (
   <div className={styles.card}>


### PR DESCRIPTION
1) Adds a new page that wraps a hubspot Meeting embed.  It defaults to @fancyremarker's calendar, but this can be overridden by passing in a `?calendarId=` query param.
2) Adds LinkedIn Insight tag so we can track chat campaign conversions into this page
3) Updates all Lead Forms to redirect to the Meeting embed page, so demo requesters can schedule a time on Frank's calendar immediately
4) Fixed all of the React warnings that have been accruing over time. 
5) Adds additional input field to the AWS Activate Form