### PR TITLE
Fix the meeting widget embed

### DIFF
--- a/src/pages/p/schedule-a-demo.js
+++ b/src/pages/p/schedule-a-demo.js
@@ -31,6 +31,7 @@ export default () => {
         />
         <script
           type="text/javascript"
+          defer
           src="//static.hsappstatic.net/MeetingsEmbed/ex/MeetingsEmbedCode.js"
         />
       </Helmet>


### PR DESCRIPTION
This works by deferring the hubspot script until dom ready. Here it is running locally on a production build: 

<img width="726" alt="Screen Shot 2021-09-29 at 3 48 39 PM" src="https://user-images.githubusercontent.com/884151/135359037-7bfb6a2e-de07-426b-affd-638222ff4233.png">
.