### PR TITLE
dont schedule demo from hipaa guide

### DIFF
--- a/src/components/hipaa-gated-form/index.js
+++ b/src/components/hipaa-gated-form/index.js
@@ -32,6 +32,7 @@ export default () => {
               id="hipaa-guide"
               btnText="Get the Guide"
               successText="Thanks!  Redirecting to our HIPAA guide"
+              scheduleDemoOnSubmit={false}
               onSuccess={onComplete}
             />
           </div>


### PR DESCRIPTION
We shouldn't redirect to the demo scheduler when capturing leads in the HIPAA Gate!