### PR TITLE
Minimum work required to list our current openings

### DIFF
--- a/src/components/careers/CurrentOpenings.js
+++ b/src/components/careers/CurrentOpenings.js
@@ -26,38 +26,15 @@ export default ({ jobs }) => (
         <h1>Current Openings</h1>
       </div>
 
-      <div className={styles.jobsList}>
-        {jobs.map((job, idx) => (
-          <div className={styles.job} key={idx}>
-            <a
-              href={job.node.hostedUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Grid>
-                <div className={styles.team}>
-                  <h6 className="small">{job.node.categories.team}</h6>
-                </div>
-                <div className={styles.jobTitle}>
-                  <h5>{job.node.text}</h5>
-                </div>
-                <div className={styles.location}>
-                  <h6 className="small">{job.node.categories.location}</h6>
-                </div>
-                <div className={styles.commitment}>
-                  <div className={styles.arrow}>{arrowIcon}</div>
-                </div>
-              </Grid>
-            </a>
-          </div>
-        ))}
-      </div>
-
       <div className={styles.cta}>
-        <ArrowButton
+        <div><ArrowButton
+          href="https://boards.greenhouse.io/aptible"
+          text="Check out our current openings"
+        /></div>
+        <div><ArrowButton
           to="/owners-manual/interviewing-with-aptible/"
           text="Learn More About Interviewing with Aptible"
-        />
+        /></div>
       </div>
     </Grid>
   </div>

--- a/src/components/careers/CurrentOpenings.module.css
+++ b/src/components/careers/CurrentOpenings.module.css
@@ -5,7 +5,6 @@
 .headline {
   grid-row: 1;
   grid-column: 2 / span 6;
-  margin-bottom: 60px;
 }
 
 .jobsList {

--- a/src/components/careers/Hero.js
+++ b/src/components/careers/Hero.js
@@ -10,7 +10,7 @@ export default () => (
       <h1 className="hero">
         Want to build the future of privacy and security on the web? Join us.
       </h1>
-      <Button to="/careers/#openings">See Job Openings</Button>
+      <Button href="https://boards.greenhouse.io/aptible">See Job Openings</Button>
     </div>
   </Grid>
 );


### PR DESCRIPTION
It's not exactly beautiful, but it does get our openings listed asap.

Goes from 

<img width="569" alt="Screen Shot 2021-10-20 at 4 54 46 PM" src="https://user-images.githubusercontent.com/2728248/138170823-2fc45ed3-c9af-41a6-815d-a4fd27ba3c79.png">

To 

<img width="485" alt="Screen Shot 2021-10-20 at 4 58 04 PM" src="https://user-images.githubusercontent.com/2728248/138171039-ec905995-918e-44eb-8cb3-b87b3871fb9b.png">

