### PR TITLE
Add redirects for 3 broken documentation links in Demo App

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -164,6 +164,9 @@ http {
     rewrite ^/documentation/(deploy|enclave)/reference/databases/endpoints.html$ https://deploy-docs.aptible.com/docs/database-endpoints permanent;
     rewrite ^/documentation/(deploy|enclave)/tutorials.html$ https://deploy-docs.aptible.com/ permanent;
     rewrite ^/documentation/faq/(deploy|enclave)/whenever.html$ https://deploy-docs.aptible.com/discuss/5f596287388855003aec719b permanent;
+    rewrite ^/documentation/faq/(deploy|enclave)/reference/apps/scaling.html$ https://deploy-docs.aptible.com/docs/scaling permanent;
+    rewrite ^/documentation/faq/(deploy|enclave)/reference/apps/endpoints/https-endpoints/https-redirect.html$ https://deploy-docs.aptible.com/docs/https-redirect permanent;
+    rewrite ^/documentation/faq/(deploy|enclave)/reference/apps/endpoints/timeouts.html$ https://deploy-docs.aptible.com/docs/endpoint-timeouts permanent;
 
     rewrite ^/gdpr/articles/?$ https://conveyor.com/gdpr/1-subject-matter-objectives permanent;
     rewrite ^/gdpr/articles/1/?$ https://conveyor.com/gdpr/1-subject-matter-objectives permanent;


### PR DESCRIPTION
The 3 unchecked docs links here are broken (the rest work); this fixes that a bit more quickly/easily than updating the Demo App code and re-deploying the associated Docker image. (It's also more robust in case these old links are referenced in other places.)

![image](https://user-images.githubusercontent.com/156030/138493508-74168b5e-8ad0-4c8f-aad0-ecb99fbdff44.png)
