### PR TITLE
Product signup landing pages

### DIFF
--- a/src/pages/p/VideoLandingPage.module.css
+++ b/src/pages/p/VideoLandingPage.module.css
@@ -54,6 +54,7 @@
   display: flex;
   align-items: center;
   flex-direction: column;
+  padding: 4rem 0;
 }
 
 .testimonialImage {
@@ -92,6 +93,16 @@
 
 .formWrapper {
   margin-bottom: 48px;
+}
+
+.signupFormWrapper {
+  margin-bottom: 48px;
+  width: 45%;
+}
+
+.signupFormWrapperBig {
+  margin-bottom: 48px;
+  width: 55%;
 }
 
 .meetingsFormWrapper {
@@ -133,5 +144,10 @@
 
   .meetingsFormWrapper {
     width: 100%;
+  }
+
+  .signupFormWrapper,
+  .signupFormWrapperBig {
+    width: 90%;
   }
 }

--- a/src/pages/p/hipaa-free-credits.js
+++ b/src/pages/p/hipaa-free-credits.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import classnames from 'classnames';
+
+import Title from './components/Title';
+import Video from './components/Video';
+import Testimonial from './components/Testimonial';
+import SignupForm from '../../components/signup-form';
+import ZeroTo from '../../components/footer/ZeroTo';
+import styles from './VideoLandingPage.module.css';
+
+export default () => {
+  return (
+    <div>
+      <Helmet>
+        <title>Aptible | HIPAA-Readiness in Deploy</title>
+        <meta
+          name="description"
+          content="Go from zero to HIPAA-Compliant docker deployment in minutes"
+        />
+        <meta
+          property="og:image"
+          content="https://aptible.com/assets/hipaa-readiness-meta.png"
+        />
+      </Helmet>
+      <div className={styles.layout}>
+        <div className={classnames(styles.container, styles.textCenter)}>
+          <Title
+            title="Deploy a Secure, HIPAA-Compliant App From Day One"
+            summary="Don’t waste engineering time building compliance into your cloud
+          infrastructure. Aptible is a PaaS that lets you be HIPAA-compliant from day
+          one. Sign up today and get $499 in free credits."
+          />
+
+          <div className={styles.signupFormWrapperBig}>
+            <SignupForm
+              id="Paid - HIPAA 499 Free Credits"
+              btnText="Get $499 in Free Credits"
+              inputPlaceholder="Enter your work email"
+            />
+          </div>
+
+          <Video />
+          <Testimonial />
+        </div>
+      </div>
+      <ZeroTo />
+    </div>
+  );
+};

--- a/src/pages/p/hipaa-free-month.js
+++ b/src/pages/p/hipaa-free-month.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import classnames from 'classnames';
+
+import Title from './components/Title';
+import Video from './components/Video';
+import Testimonial from './components/Testimonial';
+import SignupForm from '../../components/signup-form';
+import ZeroTo from '../../components/footer/ZeroTo';
+import styles from './VideoLandingPage.module.css';
+
+export default () => {
+  return (
+    <div>
+      <Helmet>
+        <title>Aptible | HIPAA-Readiness in Deploy</title>
+        <meta
+          name="description"
+          content="Go from zero to HIPAA-Compliant docker deployment in minutes"
+        />
+        <meta
+          property="og:image"
+          content="https://aptible.com/assets/hipaa-readiness-meta.png"
+        />
+      </Helmet>
+      <div className={styles.layout}>
+        <div className={classnames(styles.container, styles.textCenter)}>
+          <Title
+            title="Deploy a Secure, HIPAA-Compliant App From Day One"
+            summary="Don’t waste engineering time building compliance into your cloud
+          infrastructure. Aptible is a PaaS that lets you be HIPAA-compliant from day
+          one. Sign up today and your first month is free."
+          />
+
+          <div className={styles.signupFormWrapperBig}>
+            <SignupForm
+              id="Paid - HIPAA First Month Free"
+              btnText="Get Your 1st Month Free"
+              inputPlaceholder="Enter your work email"
+            />
+          </div>
+
+          <Video />
+          <Testimonial />
+        </div>
+      </div>
+      <ZeroTo />
+    </div>
+  );
+};

--- a/src/pages/p/hipaa-signup.js
+++ b/src/pages/p/hipaa-signup.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import classnames from 'classnames';
+
+import Title from './components/Title';
+import Video from './components/Video';
+import Testimonial from './components/Testimonial';
+import SignupForm from '../../components/signup-form';
+import ZeroTo from '../../components/footer/ZeroTo';
+import styles from './VideoLandingPage.module.css';
+
+export default () => {
+  return (
+    <div>
+      <Helmet>
+        <title>Aptible | HIPAA-Readiness in Deploy</title>
+        <meta
+          name="description"
+          content="Go from zero to HIPAA-Compliant docker deployment in minutes"
+        />
+        <meta
+          property="og:image"
+          content="https://aptible.com/assets/hipaa-readiness-meta.png"
+        />
+      </Helmet>
+      <div className={styles.layout}>
+        <div className={classnames(styles.container, styles.textCenter)}>
+          <Title
+            title="Deploy a Secure, HIPAA-Compliant App From Day One"
+            summary="Don’t waste engineering time building compliance into your cloud
+          infrastructure. Aptible is a PaaS that lets you be HIPAA-compliant from day
+          one. Watch the video below to see how."
+          />
+
+          <div className={styles.signupFormWrapper}>
+            <SignupForm
+              id="Paid - HIPAA Signup"
+              inputPlaceholder="Enter your work email"
+            />
+          </div>
+
+          <Video />
+          <Testimonial />
+        </div>
+      </div>
+      <ZeroTo />
+    </div>
+  );
+};


### PR DESCRIPTION
Adds 3 new landing pages for paid, with product signup CTAs:

- `/p/hipaa-signup/`: standard product signup
- `/p/hipaa-free-credits/`: $499 in free credits offer
- `/p/hipaa-free-month/`: first month free offer

Example from the free credits offer:
<img width="1364" alt="Screen Shot 2021-11-15 at 10 41 37 AM" src="https://user-images.githubusercontent.com/141289/141810677-281a4ff3-fd4d-4731-a626-2f8fa024af49.png">

