### PR TITLE
Add 2021 year in review page and banner

### DIFF
--- a/src/components/company/Hero.module.css
+++ b/src/components/company/Hero.module.css
@@ -37,6 +37,11 @@
   margin-bottom: 45px;
 }
 
+.video {
+  width: 640px;
+  height: 320px;
+}
+
 @media (--mobile) {
   .container {
     margin-bottom: 0;

--- a/src/components/layouts/AptibleLayout.js
+++ b/src/components/layouts/AptibleLayout.js
@@ -8,10 +8,10 @@ import Analytics from '../shared/Analytics';
 const AptibleLayout = ({ children }) => (
   <>
     <HelloBar
-      id="blog-greater-focus-on-deploy-as-comply-becomes-conveyor"
-      to="/blog/greater-focus-on-deploy-as-comply-becomes-conveyor/"
-      callout="Announcement"
-      text="Aptible Comply is now Conveyor. Click here to learn more."
+      id="p-2021-year-in-review"
+      to="/p/2021-year-in-review"
+      callout="2021 Year in Review"
+      text="Watch Aptible CEO, Frank Macreery, review highlights from 2021 and preview what's coming in 2022."
     />
     <Header />
     <CookieConsent />

--- a/src/pages/p/2021-year-in-review.js
+++ b/src/pages/p/2021-year-in-review.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import classnames from 'classnames';
+
+import Title from './components/Title';
+import Video from './components/Video';
+import Testimonial from './components/Testimonial';
+import LeadForm from '../../components/lead-form';
+import WistiaVideo from '../../components/shared/WistiaVideo';
+
+import styles from './VideoLandingPage.module.css';
+
+export default () => {
+  return (
+    <div>
+      <Helmet>
+        <title>Aptible | 2021 Year in Review</title>
+        <meta
+          name="description"
+          content="Go from zero to HITRUST-compliant Docker deployment in minutes"
+        />
+        <meta
+          property="og:image"
+          content="https://aptible.com/assets/hipaa-readiness-meta.png"
+        />
+      </Helmet>
+      <div className={styles.layout}>
+        <div className={classnames(styles.container, styles.textCenter)}>
+          <Title
+            title="2021 - Year in Review"
+            summary="2021 was a big year for Aptible. Check out the video below for a
+            review of the past year's highlights and get a sneak peek into what's coming in 2022
+            from Aptible CEO, Frank Macreery."
+          />
+
+          <Video videoId='rkkz1ahq2q' />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/p/components/Video.js
+++ b/src/pages/p/components/Video.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
 import styles from '../VideoLandingPage.module.css';
-export default () => {
+export default ({ videoId="faliwbcnei" }) => {
   return (
     <div className={styles.video}>
       <Helmet>
         <script
-          src="https://fast.wistia.com/embed/medias/faliwbcnei.jsonp"
+          src={`https://fast.wistia.com/embed/medias/${videoId}.jsonp`}
           async
         />
         <script src="https://fast.wistia.com/assets/external/E-v1.js" async />
@@ -28,7 +28,7 @@ export default () => {
           }}
         >
           <div
-            className="wistia_embed wistia_async_faliwbcnei videoFoam=true"
+            className={`wistia_embed wistia_async_${videoId} videoFoam=true`}
             style={{ height: '100%', position: 'relative', width: '100%' }}
           >
             <div
@@ -44,7 +44,7 @@ export default () => {
               }}
             >
               <img
-                src="https://fast.wistia.com/embed/medias/faliwbcnei/swatch"
+                src={`https://fast.wistia.com/embed/medias/${videoId}/swatch`}
                 style={{
                   filter: 'blur(5px)',
                   height: '100%',


### PR DESCRIPTION
Contentful is still down, so I created a page manually to get this thing shipped. 

**Banner**
<img width="1400" alt="Screen Shot 2021-12-13 at 9 57 38 PM" src="https://user-images.githubusercontent.com/884151/145941615-76638604-0a7c-4607-a2e0-503fba7b7962.png">

**Page**
<img width="1549" alt="Screen Shot 2021-12-13 at 9 57 25 PM" src="https://user-images.githubusercontent.com/884151/145941627-8647bf20-15c9-4060-a292-4432df15e083.png">

