### PR TITLE
Add community links to footer and resource nav

### DIFF
--- a/src/components/footer/Footer.js
+++ b/src/components/footer/Footer.js
@@ -90,13 +90,9 @@ const Footer = () => (
 
       <div className={styles.support}>
         <h6 className="small">Support</h6>
-        <a
-          href="https://aptible.zendesk.com/hc/en-us/requests/new"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Contact Support
-        </a>
+        <a href="https://community.aptible.com">Community</a>
+        <a href="https://deploy-docs.aptible.com">Documentation</a>
+        <a href="https://deploy-docs.aptible.com/changelog">Changelog</a>
         <a
           href="https://status.aptible.com/"
           target="_blank"
@@ -104,8 +100,13 @@ const Footer = () => (
         >
           Aptible Status
         </a>
-        <a href="https://deploy-docs.aptible.com/changelog">Changelog</a>
-        <a href="https://deploy-docs.aptible.com">Documentation</a>
+        <a
+          href="https://aptible.zendesk.com/hc/en-us/requests/new"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Contact Support
+        </a>
       </div>
 
       <div className={styles.company}>
@@ -162,6 +163,8 @@ const Footer = () => (
           <h6 className="small">support@aptible.com</h6>
         </a>
       </div>
+
+      <div className={styles.newsletter} />
 
       <div className={styles.copyright}>
         <div>

--- a/src/components/footer/Footer.module.css
+++ b/src/components/footer/Footer.module.css
@@ -62,7 +62,7 @@
 .newsletter {
   grid-row: 2;
   grid-column: 3 / span 3;
-  margin: 75px 0;
+  height: 75px;
 }
 
 .newsletter h5 {

--- a/src/components/header/ResourcesLinks.js
+++ b/src/components/header/ResourcesLinks.js
@@ -20,6 +20,13 @@ export default () => (
         Open a Ticket
       </a>
       <a
+        href="https://community.aptible.com/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Community
+      </a>
+      <a
         href="https://status.aptible.com/"
         target="_blank"
         rel="noopener noreferrer"

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -16,7 +16,7 @@ const stickyNavItems = [
   { title: 'How Aptible Works', ref: '#how-aptible-works' },
   { title: 'Solutions', ref: '#solutions' },
   { title: 'Aptible vs DIY on AWS', ref: '#aptible-vs-aws' },
-  { title: 'Who Uses Deploy', ref: '#who-uses-deploy' },
+  { title: 'Who Uses Aptible', ref: '#who-uses-deploy' },
 ];
 
 export default () => (


### PR DESCRIPTION
Addresses aptible.com items in this ticket: https://app.shortcut.com/aptible/story/1092/update-website-and-dashboard-with-links-to-community

<img width="1215" alt="Screen Shot 2021-12-27 at 2 06 52 PM" src="https://user-images.githubusercontent.com/884151/147510139-38ca9616-f1e3-40bf-9e7b-c61411dff61a.png">
<img width="1393" alt="Screen Shot 2021-12-27 at 2 07 07 PM" src="https://user-images.githubusercontent.com/884151/147510146-61886dfd-d77c-44ef-86ac-1d9d64fc1d58.png">

