### PR TITLE
Handbook redirects free emails

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -392,6 +392,9 @@ exports.createPages = async ({ graphql, actions }) => {
           markdown = markdown.replace(/\]\(\/?(?!\/?images|https|\/?handbook)/g, '](/handbook/');
           markdown = markdown.replace(/\.md/g, '/');
 
+          // Remove "read on aptible.com"
+          markdown = markdown.replace(/\*\*\[Read on aptible.*/, '');
+
           // Convert markdown to HTML
           const html = markdownConverter.makeHtml(markdown);
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -474,5 +474,13 @@ http {
     rewrite ^/documentation/enclave/reference/metrics/metric-drains/datadog.html$ https://deploy-docs.aptible.com/docs/datadog permanent;
     rewrite ^/documentation/deploy/reference/databases/credentials.html$ https://deploy-docs.aptible.com/docs/database-credentials permanent;
     rewrite ^/support/topics/enclave/how-to-run-scheduled-tasks/$ https://deploy-docs.aptible.com/docs/scheduled-tasks permanent;
+
+    rewrite ^/owners-manual/?$ /handbook/ permanent;
+    rewrite ^/owners-manual/key-operating-processes/?$ /handbook/how-we-work/ permanent;
+    rewrite ^/owners-manual/communication-architecture-and-norms/?$ /handbook/how-we-work/communicating/ permanent;
+    rewrite ^/owners-manual/team-mission-market-fit/?$ /handbook/mission-strategy/ permanent;
+    rewrite ^/owners-manual/our-values/?$ /handbook/about-aptible/values/ permanent;
+    rewrite ^/owners-manual/communicating-and-connecting/?$ /handbook/about-aptible/connecting/ permanent;
+    rewrite ^/owners-manual/interviewing-with-aptible/?$ /handbook/recruiting-process/ permanent;
   }
 }

--- a/src/components/signup-form/SignupForm.js
+++ b/src/components/signup-form/SignupForm.js
@@ -7,9 +7,18 @@ import { event, identify, trackOnLinkedIn } from '../../lib/aptible/analytics';
 import { querystring } from '../../lib/util';
 
 const utmKeywords = ['utm_campaign', 'utm_medium', 'utm_source', 'utm_term'];
+const freeEmailDomains = ['gmail.com', 'yahoo.com', 'hotmail.com'];
 
-const validateEmail = email => {
+const validateEmail = (email, allowPersonalEmails) => {
   if (!email) return { ok: false, message: 'email cannot be empty' };
+
+  if (!allowPersonalEmails) {
+    const emailTokens = email.split('@');
+    if (emailTokens.length > 1 && freeEmailDomains.indexOf(emailTokens[1]) !== -1) {
+      return { ok: false, message: 'Please use your work email address' };
+    }
+  }
+
   return { ok: true, message: '' };
 };
 
@@ -17,6 +26,7 @@ export const SignupForm = ({
   id,
   btnText = 'Sign Up For Free',
   inputPlaceholder = 'Enter your email',
+  allowPersonalEmails = true,
   onSuccess = () => { },
 }) => {
   const [submitted, setSubmitted] = useState(false);
@@ -25,7 +35,7 @@ export const SignupForm = ({
   const queryParams = queryString.parse(querystring());
 
   const onSubmit = () => {
-    const result = validateEmail(email);
+    const result = validateEmail(email, allowPersonalEmails);
     if (!result.ok) {
       setError(result.message);
       return;

--- a/src/pages/p/hipaa-free-credits.js
+++ b/src/pages/p/hipaa-free-credits.js
@@ -37,6 +37,7 @@ export default () => {
               id="Paid - HIPAA 499 Free Credits"
               btnText="Get $499 in Free Credits"
               inputPlaceholder="Enter your work email"
+              allowPersonalEmails={false}
             />
           </div>
 

--- a/src/pages/p/hipaa-free-month.js
+++ b/src/pages/p/hipaa-free-month.js
@@ -37,6 +37,7 @@ export default () => {
               id="Paid - HIPAA First Month Free"
               btnText="Get Your 1st Month Free"
               inputPlaceholder="Enter your work email"
+              allowPersonalEmails={false}
             />
           </div>
 

--- a/src/pages/p/hipaa-signup.js
+++ b/src/pages/p/hipaa-signup.js
@@ -36,6 +36,7 @@ export default () => {
             <SignupForm
               id="Paid - HIPAA Signup"
               inputPlaceholder="Enter your work email"
+              allowPersonalEmails={false}
             />
           </div>
 


### PR DESCRIPTION
- Redirects owners manual pages to handbook through nginx config
- Removes "read on aptible.com" text from all handbook markdown files (so that the link only shows on github.com)
- Prevents signups on paid landing pages from using free email domains