### PR TITLE
Policy content, handbook relative links, paid home LP

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -94,5 +94,12 @@ module.exports = {
         remote: 'https://github.com/aptible/training.git'
       },
     },
+    {
+      resolve: `gatsby-source-git`,
+      options: {
+        name: 'policy-content',
+        remote: 'https://github.com/aptible/policy-content.git'
+      },
+    },
   ],
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -389,7 +389,7 @@ exports.createPages = async ({ graphql, actions }) => {
           markdown = markdown.replace(/\/?images\//g, '/handbook-assets/');
 
           // Edit link paths
-          markdown = markdown.replace(/\]\(\/?(?!\/?images|https|\/?handbook)/g, '](/handbook/');
+          markdown = markdown.replace(/\]\(\/(?!\/?images|https|\/?handbook)/g, '](/handbook/');
           markdown = markdown.replace(/\.md/g, '/');
 
           // Remove "read on aptible.com"

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -164,6 +164,17 @@ exports.createPages = async ({ graphql, actions }) => {
             }
           }
         }
+
+        allPolicyContent: allFile(filter: { sourceInstanceName: { eq: "policy-content" } }) {
+          edges {
+            node {
+              name
+              extension
+              relativePath
+              absolutePath
+            }
+          }
+        }
       }
     `).then(result => {
       // Create pages for each blog post
@@ -422,6 +433,38 @@ exports.createPages = async ({ graphql, actions }) => {
           let imgData = fs.readFileSync(node.absolutePath);
 
           writeImage(destinationPath, imgData);
+        }
+      });
+
+      result.data.allPolicyContent.edges.forEach(async ({ node }) => {
+        if (node.extension === 'md') {
+          if (node.relativePath === 'README.md') {
+            return;
+          }
+
+          let relativePath = `policy-content/${node.relativePath.replace('.md', '').replace('policies/', '')}`;
+          if (relativePath.endsWith('/') === false) {
+            relativePath += '/';
+          }
+
+          const isPolicy = node.relativePath !== 'controls.md';
+
+          // Convert markdown to HTML
+          const markdown = fs.readFileSync(node.absolutePath).toString();
+          const html = markdownConverter.makeHtml(markdown);
+          const title = node.name.replace(/\-/g, ' ').replace(/\w\S*/g, (w) => (w.replace(/^\w/, (c) => c.toUpperCase())));
+
+          createPage({
+            path: relativePath,
+            component: path.resolve(`./src/templates/policy-content.js`),
+            context: {
+              tag: 'policy-content',
+              url: relativePath,
+              isPolicy: isPolicy,
+              html: html,
+              title: title,
+            },
+          });
         }
       });
 

--- a/src/components/deploy/CenteredDemoForm.js
+++ b/src/components/deploy/CenteredDemoForm.js
@@ -3,12 +3,12 @@ import styles from './CenteredDemoForm.module.css';
 
 import SignupForm from '../signup-form';
 
-export default ({ title, body, formId }) => (
+export default ({ title, body, formId, allowPersonalEmails = true }) => (
   <div className={styles.container}>
     <h2>{title}</h2>
     <p className="L">{body}</p>
     <div className={styles.leadFormContainer}>
-      <SignupForm id={formId} />
+      <SignupForm id={formId} allowPersonalEmails={allowPersonalEmails} />
     </div>
   </div>
 );

--- a/src/components/deploy/Hero.js
+++ b/src/components/deploy/Hero.js
@@ -29,7 +29,7 @@ const CompliancePill = ({ title, svg }) => {
   );
 };
 
-export default () => (
+export default ({ allowPersonalEmails = true }) => (
   <div className={styles.container}>
     <Grid rows="2">
       <div className={styles.content}>
@@ -53,15 +53,19 @@ export default () => (
           <SignupForm
             id="Home Page Hero - Product Signup"
             inputPlaceholder="Enter your email"
+            allowPersonalEmails={allowPersonalEmails}
           />
-          <div className={styles.signUpYourself}>
-            <p className="M">
-              Still have questions? {' '}
-              <Link to="/p/schedule-a-demo/">
-                Schedule a demo
-              </Link>
-            </p>
-          </div>
+
+          {allowPersonalEmails &&
+            <div className={styles.signUpYourself}>
+              <p className="M">
+                Still have questions? {' '}
+                <Link to="/p/schedule-a-demo/">
+                  Schedule a demo
+                </Link>
+              </p>
+            </div>
+          }
         </div>
       </div>
 

--- a/src/components/policy-content/Introduction.js
+++ b/src/components/policy-content/Introduction.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Grid } from '../grid/Grid';
+import styles from './Introduction.module.css';
+import Subnav from './Subnav';
+
+export default ({ pages }) => (
+  <div className={styles.container}>
+    <Grid>
+      <div className={styles.header}>
+        <h1>Open Source Policy Content</h1>
+      </div>
+
+      <div className={styles.content}>
+        <p className="XL">
+          Free and open-source policy content. Use the menu on the right to
+          view the policies and controls,
+          or <a href="https://github.com/aptible/policy-content">fork the repo</a> and
+          edit to make them your own.
+        </p>
+      </div>
+
+      <div className={styles.sidebar}>
+        <Subnav pages={pages} />
+      </div>
+    </Grid>
+  </div>
+);

--- a/src/components/policy-content/Introduction.module.css
+++ b/src/components/policy-content/Introduction.module.css
@@ -1,0 +1,36 @@
+.container {
+  margin-bottom: 90px;
+  margin-top: 30px;
+}
+
+.header {
+  grid-column: 1 / -1;
+  text-align: center;
+}
+
+.content {
+  grid-column: 1 / 5;
+}
+
+.content p {
+  margin-top: 60px;
+}
+
+.sidebar {
+  grid-column: 6 / span 2;
+  padding-top: 60px;
+}
+
+@media (--mobile) {
+  .container {
+    margin-bottom: 30px;
+  }
+
+  .content {
+    grid-column: 1 / -1;
+  }
+
+  .content p {
+    margin-top: 30px;
+  }
+}

--- a/src/components/policy-content/Page.js
+++ b/src/components/policy-content/Page.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Link } from 'gatsby';
+import { Grid } from '../grid/Grid';
+import styles from './Page.module.css';
+import Subnav from './Subnav';
+import ShareIcons from '../shared/ShareIcons';
+
+const titleForPage = (context) => {
+  if (context.title === 'Controls') {
+    return 'Control Library';
+  } else {
+    return context.title;
+  }
+}
+
+export default ({ pageContext, pages }) => {
+  return (
+    <div className={styles.container}>
+      <Grid>
+        <div className={styles.meta}>
+          <ShareIcons />
+
+          <h1>Open Source {titleForPage(pageContext)}</h1>
+        </div>
+
+        <div className={styles.sidebar}>
+          <Subnav pages={pages} />
+        </div>
+
+        <div className={styles.content}>
+          <div className={styles.warning}>
+            <strong>Note: </strong> Aptible is providing this content as open 
+            source for you to use in your own ISMS. The content is also available
+            on <a href="https://github.com/aptible/policy-content">Github</a>.
+            
+            <br /><br />
+            
+            <u>This is not Aptible's {titleForPage(pageContext)}</u>. For a complete
+            list of all of our policies, please visit
+            our <Link to="/legal/terms-of-service/">Legal Section</Link>.
+          </div>
+
+          <div dangerouslySetInnerHTML={{ __html: pageContext.html }} />
+        </div>
+      </Grid>
+    </div>
+  );
+};

--- a/src/components/policy-content/Page.module.css
+++ b/src/components/policy-content/Page.module.css
@@ -1,0 +1,90 @@
+.hero {
+  grid-row: 1;
+  grid-column: 1 / span 7;
+  padding: 60px 0;
+}
+
+.meta {
+  grid-row: 2;
+  grid-column: 1 / span 7;
+  padding-bottom: 60px;
+}
+
+.meta h1 {
+  padding: 3rem 0;
+}
+
+.content {
+  grid-row: 3;
+  grid-column: 1 / span 4;
+  padding-bottom: 200px;
+}
+
+.content div h1 {
+  font-size: 40px;
+  line-height: 46px;
+  margin-bottom: 40px;
+}
+
+.content div img {
+  max-width: 100%;
+}
+
+.content iframe {
+  margin: 40px 0;
+}
+
+.content blockquote {
+  margin: 3rem 0;
+  padding: 1rem 1rem 0 1rem;
+  background: var(--aptible-black-light);
+  border: 1px solid var(--grid-lines-color);
+}
+
+.content blockquote img {
+  max-width: 100%;
+}
+
+.content hr {
+  border: 0;
+  border-top: 1px solid var(--grid-lines-color);
+}
+
+.sidebar {
+  grid-row: 3;
+  grid-column: 6 / span 2;
+}
+
+.warning {
+  padding: 1rem;
+  background: linear-gradient(155.29deg, rgba(255, 255, 255, 0.04) 7.84%, rgba(255, 255, 255, 0.032) 83.16%), #0A1B2B;
+  font-size: 0.8rem;
+  margin-bottom: 3rem;
+}
+
+.warning strong {
+  color: var(--aptible-red);
+}
+
+@media (--mobile) {
+  .meta {
+    padding-bottom: 30px;
+  }
+
+  .content {
+    grid-row: 3;
+    grid-column: 1 / span 7;
+    padding-bottom: 30px;
+  }
+
+  .sidebar {
+    grid-row: 4;
+    grid-column: 1 / span 7;
+    padding-bottom: 30px;
+  }
+
+  .nextSection {
+    margin-bottom: 20px;
+    margin-top: 30px;
+  }
+}

--- a/src/components/policy-content/Subnav.js
+++ b/src/components/policy-content/Subnav.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import SidebarNav from '../shared/SidebarNav';
+import SidebarNavItem from '../shared/SidebarNavItem';
+
+const parsePages = (pages) => {
+  const policies = [];
+
+  pages.edges.forEach((page) => {
+    if (page.node.context.isPolicy) {
+      policies.push(page.node)
+    }
+  });
+
+  return policies;
+};
+
+export default ({ pages, currentPath }) => {
+  const policies = parsePages(pages);
+
+  return (
+    <SidebarNav title="Open Source Policies">
+      {policies.map(page => (
+        <SidebarNavItem
+          key={page.path}
+          to={page.path}
+          text={page.context.title}
+        />
+      ))}
+
+      <SidebarNavItem
+        key="controls"
+        to="/policy-content/controls/"
+        text="Controls"
+      />
+
+    </SidebarNav>
+  );
+};

--- a/src/data/resources.json
+++ b/src/data/resources.json
@@ -9,7 +9,13 @@
     "title": "Open Source Training Library",
     "url": "/training/",
     "description": "Free and open source training courses about common security and compliance topics.",
-    "tags": ["Training"]
+    "tags": ["Training", "Open Source"]
+  },
+  {
+    "title": "Open Source Policy Content",
+    "url": "/policy-content/",
+    "description": "Free and open source policies and controls for your ISMS.",
+    "tags": ["Open Source"]
   },
   {
     "title": "Aptible Reference Architecture",

--- a/src/pages/p/VideoLandingPage.module.css
+++ b/src/pages/p/VideoLandingPage.module.css
@@ -41,6 +41,10 @@
   background: url(/assets/radar.svg) no-repeat center 70px;
 }
 
+.homeCopyLayout {
+  padding-top: 100px;
+}
+
 .logo {
   margin-bottom: marginMd;
   width: 150px;

--- a/src/pages/p/aptible.js
+++ b/src/pages/p/aptible.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import Hero from '../../components/deploy/Hero';
+import Nav from '../../components/shared/Nav';
+
+import SecurityControls from '../../components/deploy/SecurityControls';
+import HowAptibleWorks from '../../components/deploy/HowAptibleWorks';
+import WhoUses from '../../components/deploy/WhoUses';
+import ZeroTo from '../../components/footer/ZeroTo';
+import Proof from '../../components/deploy/Proof';
+import CenteredDemoForm from '../../components/deploy/CenteredDemoForm';
+import Solutions from '../../components/deploy/Solutions';
+import styles from './VideoLandingPage.module.css';
+
+const stickyNavItems = [
+  { title: 'How Aptible Works', ref: '#how-aptible-works' },
+  { title: 'Solutions', ref: '#solutions' },
+  { title: 'Aptible vs DIY on AWS', ref: '#aptible-vs-aws' },
+  { title: 'Who Uses Aptible', ref: '#who-uses-deploy' },
+];
+
+export default () => (
+  <div>
+    <Helmet>
+      <title>Aptible | Secure, Compliant, Application Deployment</title>
+      <meta
+        name="description"
+        content="Get to market faster with a developer-friendly deployment platform that provides the security controls needed to comply with SOC 2 Type 2, HIPAA, HITRUST, and more."
+      />
+    </Helmet>
+
+    <div className={styles.homeCopyLayout}>
+      <Hero allowPersonalEmails={false} />
+      <Proof />
+      <Nav
+        items={stickyNavItems}
+        ctaText="Sign up for free"
+        product="deploy"
+      />
+      <HowAptibleWorks />
+      <CenteredDemoForm
+        title="A Trusted Platform That Grows With You"
+        body="Complete audits faster with well-documented controls, clear
+      audit trails for third parties, and all of the security and
+      compliance features you need get certified."
+        formId="Home Page - Product Signup"
+        allowPersonalEmails={false}
+      />
+      <Solutions />
+      <SecurityControls />
+      <CenteredDemoForm
+        title="Use Aptible and Deploy in Three Steps"
+        body="Save your engineering team the headache of building compliant infra on AWS. Use Aptible and get back to building your product. Request a demo to see how it works."
+        formId="Home Page - Product Signup"
+        allowPersonalEmails={false}
+      />
+      <WhoUses />
+    </div>
+    
+    <ZeroTo />
+  </div>
+);
+

--- a/src/pages/policy-content.js
+++ b/src/pages/policy-content.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import AptibleLayout from '../components/layouts/AptibleLayout';
+import Introduction from '../components/policy-content/Introduction';
+
+export default ({ data }) => {
+  const { pages } = data;
+
+  return (
+    <AptibleLayout>
+      <Helmet>
+        <title>Aptible | Policies and Controls</title>
+        <meta
+          name="description"
+          content="Free and open source ISMS policies and controls"
+        />
+      </Helmet>
+      <Introduction pages={pages} />
+    </AptibleLayout>
+  );
+};
+
+export const query = graphql`
+  {
+    pages: allSitePage(filter: { context: { tag: { eq: "policy-content"}}}) {
+      edges {
+        node {
+          path
+          context {
+            title
+            isPolicy
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/templates/policy-content.js
+++ b/src/templates/policy-content.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import AptibleLayout from '../components/layouts/AptibleLayout';
+import Page from '../components/policy-content/Page';
+import { titleize } from '../components/training/helpers';
+
+export default ({ pageContext, data }) => {
+  const { pages } = data;
+
+  return (
+    <AptibleLayout>
+      <Helmet>
+        <title>{"Open Source " + titleize(pageContext.title)}</title>
+        <meta
+          name="description"
+          content={"An open source " + titleize(pageContext.title) + " for you to customize and make your own."}
+        />
+      </Helmet>
+      <Page pageContext={pageContext} pages={pages} />
+    </AptibleLayout>
+  );
+};
+
+export const query = graphql`
+  {
+    pages: allSitePage(filter: { context: { tag: { eq: "policy-content"}}}) {
+      edges {
+        node {
+          path
+          context {
+            title
+            isPolicy
+          }
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
- Adds the content & templates for the open source controls and policies section, and links to it from the resources page
- Fixes relative links in the handbook
- Adds a copy of the homepage to use as a paid landing page (not allowing personal emails on it)

The [content PR](https://github.com/aptible/policy-content/pull/1) needs to be merged and that repo needs to be public before this PR can be deployed.

<img width="1268" alt="Screen Shot 2022-01-31 at 9 15 49 PM" src="https://user-images.githubusercontent.com/141289/151903722-4f94e2e3-56ab-4446-88ef-1d51dbce692b.png">