### PR TITLE
Copy of homepage as a paid LP

### DIFF
--- a/src/components/deploy/CenteredDemoForm.js
+++ b/src/components/deploy/CenteredDemoForm.js
@@ -3,12 +3,12 @@ import styles from './CenteredDemoForm.module.css';
 
 import SignupForm from '../signup-form';
 
-export default ({ title, body, formId }) => (
+export default ({ title, body, formId, allowPersonalEmails = true }) => (
   <div className={styles.container}>
     <h2>{title}</h2>
     <p className="L">{body}</p>
     <div className={styles.leadFormContainer}>
-      <SignupForm id={formId} />
+      <SignupForm id={formId} allowPersonalEmails={allowPersonalEmails} />
     </div>
   </div>
 );

--- a/src/components/deploy/Hero.js
+++ b/src/components/deploy/Hero.js
@@ -29,7 +29,7 @@ const CompliancePill = ({ title, svg }) => {
   );
 };
 
-export default () => (
+export default ({ allowPersonalEmails = true }) => (
   <div className={styles.container}>
     <Grid rows="2">
       <div className={styles.content}>
@@ -53,15 +53,19 @@ export default () => (
           <SignupForm
             id="Home Page Hero - Product Signup"
             inputPlaceholder="Enter your email"
+            allowPersonalEmails={allowPersonalEmails}
           />
-          <div className={styles.signUpYourself}>
-            <p className="M">
-              Still have questions? {' '}
-              <Link to="/p/schedule-a-demo/">
-                Schedule a demo
-              </Link>
-            </p>
-          </div>
+
+          {allowPersonalEmails &&
+            <div className={styles.signUpYourself}>
+              <p className="M">
+                Still have questions? {' '}
+                <Link to="/p/schedule-a-demo/">
+                  Schedule a demo
+                </Link>
+              </p>
+            </div>
+          }
         </div>
       </div>
 

--- a/src/pages/p/VideoLandingPage.module.css
+++ b/src/pages/p/VideoLandingPage.module.css
@@ -41,6 +41,10 @@
   background: url(/assets/radar.svg) no-repeat center 70px;
 }
 
+.homeCopyLayout {
+  padding-top: 100px;
+}
+
 .logo {
   margin-bottom: marginMd;
   width: 150px;

--- a/src/pages/p/aptible.js
+++ b/src/pages/p/aptible.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import Hero from '../../components/deploy/Hero';
+import Nav from '../../components/shared/Nav';
+
+import SecurityControls from '../../components/deploy/SecurityControls';
+import HowAptibleWorks from '../../components/deploy/HowAptibleWorks';
+import WhoUses from '../../components/deploy/WhoUses';
+import ZeroTo from '../../components/footer/ZeroTo';
+import Proof from '../../components/deploy/Proof';
+import CenteredDemoForm from '../../components/deploy/CenteredDemoForm';
+import Solutions from '../../components/deploy/Solutions';
+import styles from './VideoLandingPage.module.css';
+
+const stickyNavItems = [
+  { title: 'How Aptible Works', ref: '#how-aptible-works' },
+  { title: 'Solutions', ref: '#solutions' },
+  { title: 'Aptible vs DIY on AWS', ref: '#aptible-vs-aws' },
+  { title: 'Who Uses Aptible', ref: '#who-uses-deploy' },
+];
+
+export default () => (
+  <div>
+    <Helmet>
+      <title>Aptible | Secure, Compliant, Application Deployment</title>
+      <meta
+        name="description"
+        content="Get to market faster with a developer-friendly deployment platform that provides the security controls needed to comply with SOC 2 Type 2, HIPAA, HITRUST, and more."
+      />
+    </Helmet>
+
+    <div className={styles.homeCopyLayout}>
+      <Hero allowPersonalEmails={false} />
+      <Proof />
+      <Nav
+        items={stickyNavItems}
+        ctaText="Sign up for free"
+        product="deploy"
+      />
+      <HowAptibleWorks />
+      <CenteredDemoForm
+        title="A Trusted Platform That Grows With You"
+        body="Complete audits faster with well-documented controls, clear
+      audit trails for third parties, and all of the security and
+      compliance features you need get certified."
+        formId="Home Page - Product Signup"
+        allowPersonalEmails={false}
+      />
+      <Solutions />
+      <SecurityControls />
+      <CenteredDemoForm
+        title="Use Aptible and Deploy in Three Steps"
+        body="Save your engineering team the headache of building compliant infra on AWS. Use Aptible and get back to building your product. Request a demo to see how it works."
+        formId="Home Page - Product Signup"
+        allowPersonalEmails={false}
+      />
+      <WhoUses />
+    </div>
+    
+    <ZeroTo />
+  </div>
+);
+


### PR DESCRIPTION
Adds a copy of the homepage to be used as a paid landing page, with 2 changes:
1. Prevents free email signups
2. Removes the main nav

<img width="1476" alt="Screen Shot 2022-04-10 at 9 52 25 PM" src="https://user-images.githubusercontent.com/141289/162652035-434cb36d-f64c-4894-b758-68b13135fe50.png">

