### PR TITLE
Add docs to top bar

### DIFF
--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -118,6 +118,11 @@ class Header extends React.Component {
                     openSectionName={openSectionName}
                   />
 
+                  <MainNavItem
+                      title="Docs"
+                      to="https://deploy-docs.aptible.com"
+                  />
+
                   <div className={styles.mobileNav}>
                     <MobileMenuItem
                       navOpen={this.state.navOpen}


### PR DESCRIPTION
Pretty boring

<img width="1093" alt="Screen Shot 2022-04-11 at 8 40 11 PM" src="https://user-images.githubusercontent.com/2728248/162855697-f8ecdc76-b50d-4809-b350-1f41a2b55c97.png">

As discussed [here](https://aptible.slack.com/archives/C026XHXHXMM/p1648652611266709)