### PR TITLE
Blog post formatting

### DIFF
--- a/src/components/blog/Post.module.css
+++ b/src/components/blog/Post.module.css
@@ -31,6 +31,10 @@
   grid-column: 2 / span 6;
 }
 
+.content h1 {
+  font-size: 52px;
+}
+
 .metaContainer {
   margin: 80px 0 45px 0;
 }
@@ -39,9 +43,11 @@
   padding: 40px 0;
 }
 
-.body h1 {
-  font-size: 40px;
+.body h1,
+.body h2 {
+  font-size: 32px;
   line-height: 46px;
+  margin: 60px 0 30px 0;
 }
 
 .body h2:not(:first-child),
@@ -55,6 +61,7 @@
 .body ul,
 .body ol {
   line-height: 1.6;
+  font-size: 18px;
 }
 
 .body li > p {
@@ -69,7 +76,7 @@
 }
 
 .body > *:not([data-module="codeblock"]):not(table) {
-  max-width: 640px;
+  max-width: 720px;
 }
 
 .body > hr {
@@ -89,8 +96,9 @@
 
 .body > table,
 .body > [data-module="codeblock"] {
-  width: var(--content-max-width);
-  margin-left: -160px;
+  font-size: 13px;
+  margin: 50px 0;
+  max-width: 720px;
 }
 
 /* override Prism theme */

--- a/src/components/deploy/Proof.js
+++ b/src/components/deploy/Proof.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styles from './Proof.module.css';
-import cn from 'classnames';
+import { Link } from 'gatsby';
 import himsHersLogo from '../../images/customers/logos/hims-hers-logo.png';
 import rightwayLogo from '../../images/customers/logos/rightway-logo.png';
 import aidinLogo from '../../images/customers/logos/aidin-logo.png';
@@ -11,7 +11,9 @@ import pagerLogo from '../../images/customers/logos/pager-logo.png';
 export default () => (
   <div className={styles.container}>
     <p className={styles.proofTitle}>
-      Hundreds of digital health companies (including 20+ unicorns 🦄) build on Aptible:
+      Hundreds of digital health companies 
+      &mdash; <Link to="/customers/">including 20+ unicorns 🦄</Link> &mdash; 
+      build on Aptible:
     </p>
     <div className={styles.logoBar}>
       <img height="24" src={himsHersLogo} alt="hims & hers" />

--- a/src/components/deploy/Proof.module.css
+++ b/src/components/deploy/Proof.module.css
@@ -8,8 +8,8 @@
 
 .proofTitle {
   margin-bottom: 32px;
-  font-size: 18px;
-  font-weight: 500;
+  font-size: 22px;
+  font-weight: 400;
   text-align: center;
 }
 

--- a/src/components/header/Resources.js
+++ b/src/components/header/Resources.js
@@ -18,11 +18,6 @@ export const RESOURCES_NAV = [
     external: false,
   },
   {
-    title: 'Engineering Blog',
-    url: '/blog/category/engineering/',
-    external: false,
-  },
-  {
     title: 'Library',
     url: '/resources/',
     external: false,

--- a/src/components/header/ResourcesLinks.js
+++ b/src/components/header/ResourcesLinks.js
@@ -7,7 +7,6 @@ export default () => (
     <div className={styles.column}>
       <a href="https://deploy-docs.aptible.com">Documentation</a>
       <Link to="/blog/">Blog</Link>
-      <Link to="/blog/category/engineering">Engineering Blog</Link>
       <Link to="/resources/">Library</Link>
 
       <h6 className="small">Support</h6>


### PR DESCRIPTION
Improves the formatting of code blocks in blog posts, makes text sizes more readable. Combines "Engineering Blog" with regular "Blog".

<img width="917" alt="Screen Shot 2022-05-15 at 8 10 40 PM" src="https://user-images.githubusercontent.com/141289/168500551-db148b87-54d3-42d2-89e8-886df4fc7541.png">
