### PR TITLE
Fix gatsby build error

### DIFF
--- a/src/pages/p/components/DemandGenSignup.js
+++ b/src/pages/p/components/DemandGenSignup.js
@@ -69,3 +69,5 @@ export const DemandGenSignup = ({
     </div>
   );
 };
+
+export default DemandGenSignup;


### PR DESCRIPTION
In production, Gatsby requires every file in `pages/` to export a react component...